### PR TITLE
Feature/display player state ios

### DIFF
--- a/ios/Classes/ConnectionStatusHandler.swift
+++ b/ios/Classes/ConnectionStatusHandler.swift
@@ -17,3 +17,20 @@ class ConnectionStatusHandler: NSObject, FlutterStreamHandler {
     }
 
 }
+
+extension ConnectionStatusHandler: SPTAppRemoteDelegate {
+    func appRemoteDidEstablishConnection(_ appRemote: SPTAppRemote) {
+        // emit connection established event
+        eventSink?("{\"connected\": true}")
+    }
+
+    func appRemote(_ appRemote: SPTAppRemote, didFailConnectionAttemptWithError error: Error?) {
+        //
+    }
+
+    func appRemote(_ appRemote: SPTAppRemote, didDisconnectWithError error: Error?) {
+        eventSink?(FlutterError(code: "UNAVAILABLE", message: "Battery info unavailable", details: nil))
+    }
+
+
+}

--- a/ios/Classes/ConnectionStatusHandler.swift
+++ b/ios/Classes/ConnectionStatusHandler.swift
@@ -1,27 +1,18 @@
-import Flutter
-import UIKit
 import SpotifyiOS
 
-class ConnectionStatusHandler: NSObject, FlutterStreamHandler {
+class ConnectionStatusHandler: StatusHandler, SPTAppRemoteDelegate {
 
-    private var eventSink: FlutterEventSink?
+    private var onConnect: (()->())?
 
-    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-        eventSink = events
-        return nil
+    init(onConnect: (()->())? ) {
+        super.init()
+        self.onConnect = onConnect
     }
 
-    public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        eventSink = nil;
-        return nil
-    }
-
-}
-
-extension ConnectionStatusHandler: SPTAppRemoteDelegate {
     func appRemoteDidEstablishConnection(_ appRemote: SPTAppRemote) {
         // emit connection established event
         eventSink?("{\"connected\": true}")
+        onConnect?()
     }
 
     func appRemote(_ appRemote: SPTAppRemote, didFailConnectionAttemptWithError error: Error?) {
@@ -29,8 +20,6 @@ extension ConnectionStatusHandler: SPTAppRemoteDelegate {
     }
 
     func appRemote(_ appRemote: SPTAppRemote, didDisconnectWithError error: Error?) {
-        eventSink?(FlutterError(code: "UNAVAILABLE", message: "Battery info unavailable", details: nil))
+        eventSink?(FlutterError(code: "didDisconnectWithError", message: error?.localizedDescription, details: nil))
     }
-
-
 }

--- a/ios/Classes/PlayerContextHandler.swift
+++ b/ios/Classes/PlayerContextHandler.swift
@@ -1,0 +1,5 @@
+import SpotifyiOS
+
+class PlayerContextHandler: StatusHandler {
+
+}

--- a/ios/Classes/PlayerStateHandler.swift
+++ b/ios/Classes/PlayerStateHandler.swift
@@ -1,0 +1,98 @@
+import SpotifyiOS
+
+class PlayerStateHandler: StatusHandler, SPTAppRemotePlayerStateDelegate {
+
+    private var appRemote: SPTAppRemote
+    private var subscribedToPlayerState = false
+
+    init (appRemote: SPTAppRemote) {
+        self.appRemote = appRemote
+        super.init()
+    }
+
+    func playerStateDidChange(_ playerState: SPTAppRemotePlayerState) {
+        print("playerStateDidChange")
+        eventSink?(stateJson(playerState).json)
+    }
+
+    func subscribeToPlayerState() {
+        print("Subscribed to player state")
+        guard !subscribedToPlayerState else { return }
+        appRemote.playerAPI!.delegate = self
+        appRemote.playerAPI?.subscribe { (_, error) -> Void in
+            guard error == nil else { return }
+            self.subscribedToPlayerState = true
+        }
+    }
+
+    override func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        _ = super.onListen(withArguments: arguments, eventSink: events)
+        subscribeToPlayerState()
+        return nil
+    }
+
+    private func stateJson(_ playerState: SPTAppRemotePlayerState) -> [String : Any] {
+        let artist = [
+            "name" : playerState.track.artist.name,
+            "uri" : playerState.track.artist.uri
+        ]
+
+        let album = [
+            "name" : playerState.track.album.name,
+            "uri" : playerState.track.album.uri
+        ]
+
+        let imageIdentifier = [
+            "raw" : playerState.track.imageIdentifier
+
+        ]
+
+        let track: [String : Any] = [
+            "album" : album,
+            "artist" : artist,
+            "artists" : [artist],
+            "duration_ms" : playerState.track.duration,
+            "image_id" : imageIdentifier,
+            "is_episode" : playerState.track.isEpisode,
+            "is_podcast" : playerState.track.isPodcast,
+            "name" : playerState.track.name,
+            "uri" : playerState.track.uri
+        ]
+
+        let playbackOptions: [String : Any] = [
+            "shuffle" : playerState.playbackOptions.isShuffling,
+            "repeat" : playerState.playbackOptions.repeatMode.rawValue
+        ]
+
+        let playbackRestrictions = [
+            "can_skip_next" : playerState.playbackRestrictions.canSkipNext,
+            "can_skip_prev" : playerState.playbackRestrictions.canSkipPrevious,
+            "can_repeat_track" : playerState.playbackRestrictions.canRepeatTrack,
+            "can_repeat_context" : playerState.playbackRestrictions.canRepeatContext,
+            "can_toggle_shuffle" : playerState.playbackRestrictions.canToggleShuffle,
+            "can_seek" : playerState.playbackRestrictions.canSeek
+        ]
+
+        return [
+            "track" : track,
+            "is_paused" : playerState.isPaused,
+            "playback_speed" : playerState.playbackSpeed,
+            "playback_position" : playerState.playbackPosition,
+            "playback_options" : playbackOptions,
+            "playback_restrictions" : playbackRestrictions
+        ]
+    }
+}
+
+extension Dictionary {
+
+    var json: String {
+        let invalidJson = "Invalid JSON"
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: self, options: .prettyPrinted)
+            return String(bytes: jsonData, encoding: String.Encoding.utf8) ?? invalidJson
+        } catch {
+            return invalidJson
+        }
+    }
+}

--- a/ios/Classes/StatusHandler.swift
+++ b/ios/Classes/StatusHandler.swift
@@ -1,0 +1,17 @@
+import Flutter
+import UIKit
+import SpotifyiOS
+
+class StatusHandler: NSObject, FlutterStreamHandler {
+    var eventSink: FlutterEventSink?
+
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        eventSink = events
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        eventSink = nil;
+        return nil
+    }
+}

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -5,6 +5,8 @@ import SpotifyiOS
 public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
 
     var appRemote: SPTAppRemote?
+    var connectionStatusHandler = ConnectionStatusHandler()
+
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let spotifySDKChannel = FlutterMethodChannel(name: "spotify_sdk", binaryMessenger: registrar.messenger())
@@ -14,7 +16,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
         registrar.addApplicationDelegate(instance)
 
         registrar.addMethodCallDelegate(instance, channel: spotifySDKChannel)
-        connectionStatusChannel.setStreamHandler(ConnectionStatusHandler())
+        connectionStatusChannel.setStreamHandler(instance.connectionStatusHandler)
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -41,6 +43,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
         guard let redirectURL = URL(string: redirectURL) else { return }
         let configuration = SPTConfiguration(clientID: clientId, redirectURL: redirectURL)
         appRemote = SPTAppRemote(configuration: configuration, logLevel: .none)
+        appRemote?.delegate = connectionStatusHandler
 
         // Note: A blank string will play the user's last song or pick a random one.
         if appRemote?.authorizeAndPlayURI("") == false {


### PR DESCRIPTION
This PR shows the player state in the example app on connection and on state change.

Please verify this: If I understood the Android code correctly you didn't explicitly specify the Json keys but used them as they were in the serialized objects. I modeled the Swift code after those names so I had to specify them manually.