### PR TITLE
Adapt to breaking change in the android Spotify SDK

### DIFF
--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -222,7 +222,7 @@ class SpotifySdkPlugin(private val registrar: Registrar) : MethodCallHandler, Pl
                                 }
                                 is NotLoggedInException -> {
                                     errorMessage = "User has logged out from Spotify."
-                                    errorCode = "LoggedOutException"
+                                    errorCode = "NotLoggedInException"
                                 }
                                 is SpotifyRemoteServiceException -> {
                                     errorMessage = "Encapsulates possible SecurityException and IllegalStateException errors."

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -220,7 +220,7 @@ class SpotifySdkPlugin(private val registrar: Registrar) : MethodCallHandler, Pl
                                     errorCode = "OfflineModeException"
                                     connected = true
                                 }
-                                is LoggedOutException -> {
+                                is NotLoggedInException -> {
                                     errorMessage = "User has logged out from Spotify."
                                     errorCode = "LoggedOutException"
                                 }


### PR DESCRIPTION
The LoggedOutException in the Spotify SDK has been renamed to NotLoggedInException as mentioned [here](https://github.com/spotify/android-sdk/releases/tag/v0.7.1-appremote_v1.2.3-auth). This PR adapts to these changes.