### PR TITLE
Change wget to curl command in prepare-iOS-SDK, as wget is not available in MacOS by default.

### DIFF
--- a/ios/prepare-iOS-SDK.sh
+++ b/ios/prepare-iOS-SDK.sh
@@ -8,7 +8,7 @@ fi
 
 rm -fR ios-sdk
 mkdir ios-sdk
-wget -c https://github.com/spotify/ios-sdk/archive/v1.2.2.zip
+curl -OL https://github.com/spotify/ios-sdk/archive/v1.2.2.zip
 unzip -o v1.2.2.zip
 mv ios-sdk-1.2.2/SpotifyiOS.framework ios-sdk
 rm v1.2.2.zip


### PR DESCRIPTION
The `wget https://github.com/spotify/ios-sdk/archive/v1.2.2.zip` command used in script prepare-iOS-SDK.sh is not available on MacOS. I replaced it with `curl -OL https://github.com/spotify/ios-sdk/archive/v1.2.2.zip`. `curl -OL` has the same functionality as `wget` in this case.