### PR TITLE
Implemented the PKCE authorization flow for the web platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ After you are all setup you need to add `SpotifyiOS.framework` to your iOS Proje
 
 2. Paste the following onto the webpage, which you linked to in your redirect URL.  
 ```html
-  <!DOCTYPE html>
-  <html>
+<!DOCTYPE html>
+<html>
   <head>
     <title>Authenticating Spotify</title>
   </head>
@@ -49,27 +49,12 @@ After you are all setup you need to add `SpotifyiOS.framework` to your iOS Proje
 	<p>Please wait while we authenticate Spotify...</p>
 	<script type="text/javascript">
 		if(window.opener) {
-			var error = getParameterByName('error');
-			if(error) {
-				window.opener.postMessage('?' + error, "*");
-			} else {
-				window.opener.postMessage(window.location.hash, "*");
-			}
+			window.opener.postMessage('?' + window.location.href.split('?')[1], "*");
 		} else {
 			window.close();
 		}
-
-		function getParameterByName(name, url) {
-		    if (!url) url = window.location.href;
-		    name = name.replace(/[\[\]]/g, '\\$&');
-		    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-		        results = regex.exec(url);
-		    if (!results) return null;
-		    if (!results[2]) return '';
-		    return decodeURIComponent(results[2].replace(/\+/g, ' '));
-		}
 	</script>
-</body>
+  </body>
 </html>
 ```
 

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -423,22 +423,21 @@ class SpotifySdkPlugin {
       await sub.cancel();
 
       // exchange auth code for access and refresh tokens
-      var response =
-          await _authDio.post('https://accounts.spotify.com/api/token',
-              data: {
-                'client_id': clientId,
-                'grant_type': 'authorization_code',
-                'code': parsedMessage.queryParameters['code'],
-                'redirect_uri': redirectUrl,
-                'code_verifier': codeVerifier
-              },
-              options: Options(contentType: Headers.formUrlEncodedContentType));
-
-      if (response.statusCode == 200) {
-        return response.data;
-      } else {
-        throw PlatformException(
-            message: "Token exchange failed", code: "Authentication Error");
+      try {
+        return (await _authDio.post('https://accounts.spotify.com/api/token',
+                data: {
+                  'client_id': clientId,
+                  'grant_type': 'authorization_code',
+                  'code': parsedMessage.queryParameters['code'],
+                  'redirect_uri': redirectUrl,
+                  'code_verifier': codeVerifier
+                },
+                options:
+                    Options(contentType: Headers.formUrlEncodedContentType)))
+            .data;
+      } on DioError catch (e) {
+        print('Spotify auth error: ${e.response?.data}');
+        rethrow;
       }
     } else {
       throw PlatformException(

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -343,7 +343,8 @@ class SpotifySdkPlugin {
   /// reauthenticates the user if the token expired.
   Future<String> _getSpotifyAuthToken(
       {String clientId, String redirectUrl}) async {
-    if (_spotifyToken?.accessToken != null) {
+    if (_spotifyToken?.accessToken != null &&
+        _spotifyToken?.refreshToken != null) {
       // attempt to use the previously authorized credentials
       if (_spotifyToken.expiry > DateTime.now().millisecondsSinceEpoch / 1000) {
         // access token valid
@@ -460,7 +461,7 @@ class SpotifySdkPlugin {
       return response.data;
     } else {
       throw PlatformException(
-          message: "Token exchange failed", code: "Authentication Error");
+          message: "${response.data}", code: "Token Refresh Error");
     }
   }
 

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -395,7 +395,7 @@ class SpotifySdkPlugin {
           'https://accounts.spotify.com/authorize?client_id=$clientId&response_type=code&redirect_uri=$redirectUrl&code_challenge_method=S256&code_challenge=$codeChallenge&state=$state&scope=$scopes';
 
       // opening auth window
-      var authPopup = window.open(authorizationUri, "Spotify Authorization");
+      var authPopup = window.open(authorizationUri, 'Spotify Authorization');
       String message;
       var sub = window.onMessage.listen(allowInterop((event) {
         message = event.data.toString();
@@ -413,7 +413,7 @@ class SpotifySdkPlugin {
       // check if state is the same
       if (state != parsedMessage.queryParameters['state']) {
         throw PlatformException(
-            message: "Invalid state", code: "Authentication Error");
+            message: 'Invalid state', code: 'Authentication Error');
       }
 
       // check for error
@@ -421,7 +421,7 @@ class SpotifySdkPlugin {
           parsedMessage.queryParameters['code'] == null) {
         throw PlatformException(
             message: "${parsedMessage.queryParameters['error']}",
-            code: "Authentication Error");
+            code: 'Authentication Error');
       }
 
       // close auth window
@@ -484,7 +484,7 @@ class SpotifySdkPlugin {
   String _createCodeChallenge(String codeVerifier) {
     return base64Url
         .encode(sha256.convert(ascii.encode(codeVerifier)).bytes)
-        .replaceAll("=", "");
+        .replaceAll('=', '');
   }
 
   /// Creates a random string unique to a given authentication session.

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -1,5 +1,5 @@
 @JS()
-library spotify_sdk;
+library spotify_sdk_web;
 
 import 'dart:async';
 import 'dart:convert';

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -10,6 +10,7 @@ import 'dart:js';
 import 'dart:math' as math;
 
 import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js.dart';
@@ -343,17 +344,17 @@ class SpotifySdkPlugin {
   /// reauthenticates the user if the token expired.
   Future<String> _getSpotifyAuthToken(
       {String clientId, String redirectUrl}) async {
-    if (_spotifyToken?.accessToken != null &&
-        _spotifyToken?.refreshToken != null) {
+    if (_spotifyToken?.accessToken != null) {
       // attempt to use the previously authorized credentials
       if (_spotifyToken.expiry > DateTime.now().millisecondsSinceEpoch / 1000) {
         // access token valid
         return _spotifyToken.accessToken;
       } else {
         // access token invalid, refresh it
-        var newToken =
-            await _refreshSpotifyToken(clientId, _spotifyToken.refreshToken);
+        var newToken = await _refreshSpotifyToken(
+            _spotifyToken.clientId, _spotifyToken.refreshToken);
         _spotifyToken = SpotifyToken(
+            clientId: _spotifyToken.clientId,
             accessToken: newToken['access_token'] as String,
             refreshToken: newToken['refresh_token'] as String,
             expiry: (DateTime.now().millisecondsSinceEpoch / 1000).round() +
@@ -364,6 +365,7 @@ class SpotifySdkPlugin {
       // new authorization
       var newToken = await _authorizeSpotify(clientId, redirectUrl);
       _spotifyToken = SpotifyToken(
+          clientId: clientId,
           accessToken: newToken['access_token'] as String,
           refreshToken: newToken['refresh_token'] as String,
           expiry: (DateTime.now().millisecondsSinceEpoch / 1000).round() +
@@ -919,6 +921,9 @@ class WebPlaybackError {
 
 /// Spotify token object.
 class SpotifyToken {
+  /// Currently used client id.
+  final String clientId;
+
   /// Access token data.
   final String accessToken;
 
@@ -929,5 +934,9 @@ class SpotifyToken {
   final int expiry;
 
   // ignore: public_member_api_docs
-  SpotifyToken({this.accessToken, this.refreshToken, this.expiry});
+  SpotifyToken(
+      {@required this.clientId,
+      @required this.accessToken,
+      @required this.refreshToken,
+      @required this.expiry});
 }

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -449,19 +449,18 @@ class SpotifySdkPlugin {
   /// Refreshes the Spotify access token using the refresh token.
   Future<dynamic> _refreshSpotifyToken(
       String clientId, String refreshToken) async {
-    var response = await _authDio.post('https://accounts.spotify.com/api/token',
-        data: {
-          'grant_type': 'refresh_token',
-          'refresh_token': refreshToken,
-          'client_id': clientId,
-        },
-        options: Options(contentType: Headers.formUrlEncodedContentType));
-
-    if (response.statusCode == 200) {
-      return response.data;
-    } else {
-      throw PlatformException(
-          message: "${response.data}", code: "Token Refresh Error");
+    try {
+      return (await _authDio.post('https://accounts.spotify.com/api/token',
+              data: {
+                'grant_type': 'refresh_token',
+                'refresh_token': refreshToken,
+                'client_id': clientId,
+              },
+              options: Options(contentType: Headers.formUrlEncodedContentType)))
+          .data;
+    } on DioError catch (e) {
+      print('Token refresh error: ${e.response?.data}');
+      rethrow;
     }
   }
 
@@ -541,7 +540,7 @@ class SpotifySdkPlugin {
     }
 
     await _dio.put(
-      'https://api.spotify.com/v1/me/player/shuffle',
+      '/shuffle',
       queryParameters: {'state': state, 'device_id': _currentPlayer.deviceID},
       options: Options(
         headers: {
@@ -560,7 +559,7 @@ class SpotifySdkPlugin {
     }
 
     await _dio.put(
-      'https://api.spotify.com/v1/me/player/repeat',
+      '/repeat',
       queryParameters: {'state': state, 'device_id': _currentPlayer.deviceID},
       options: Options(
         headers: {

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -3,15 +3,18 @@ library spotify_sdk;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:core';
 import 'dart:developer';
 import 'dart:html';
 import 'dart:js';
+import 'dart:math' as math;
 
 import 'package:dio/dio.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';
+import 'package:crypto/crypto.dart';
 
 import 'models/album.dart';
 import 'models/artist.dart';
@@ -56,12 +59,6 @@ class SpotifySdkPlugin {
   /// Current Spotify auth token.
   SpotifyToken _spotifyToken;
 
-  /// Cached client id used when connecting to Spotify.
-  String cachedClientId;
-
-  /// Cached redirect url used when connecting to Spotify.
-  String cachedRedirectUrl;
-
   /// player context event stream controller
   final StreamController playerContextEventController;
 
@@ -81,6 +78,7 @@ class SpotifySdkPlugin {
   final Dio _dio = Dio(BaseOptions(
     baseUrl: 'https://api.spotify.com/v1/me/player',
   ));
+  final Dio _authDio = Dio(BaseOptions());
 
   /// constructor
   SpotifySdkPlugin(
@@ -155,17 +153,17 @@ class SpotifySdkPlugin {
                   "Client id or redirectUrl are not set or have invalid format",
               code: "Authentication Error");
         }
-        cachedClientId = clientId;
-        cachedRedirectUrl = redirectUrl;
 
         // get initial token
-        await _getSpotifyAuthToken();
+        await _getSpotifyAuthToken(
+            clientId: clientId, redirectUrl: redirectUrl);
 
         // create player
         _currentPlayer = Player(PlayerOptions(
             name: playerName,
             getOAuthToken: allowInterop((Function callback, t) {
-              _getSpotifyAuthToken().then((value) {
+              _getSpotifyAuthToken(clientId: clientId, redirectUrl: redirectUrl)
+                  .then((value) {
                 callback(value);
               });
             })));
@@ -198,6 +196,7 @@ class SpotifySdkPlugin {
         break;
       case MethodNames.disconnectFromSpotify:
         log('Disconnecting from Spotify...');
+        _spotifyToken = null;
         if (_currentPlayer == null) {
           return true;
         } else {
@@ -344,69 +343,152 @@ class SpotifySdkPlugin {
   /// reauthenticates the user if the token expired.
   Future<String> _getSpotifyAuthToken(
       {String clientId, String redirectUrl}) async {
-    if (_spotifyToken != null &&
-        _spotifyToken.expiry > DateTime.now().millisecondsSinceEpoch) {
-      return _spotifyToken.token;
+    if (_spotifyToken?.accessToken != null) {
+      // attempt to use the previously authorized credentials
+      if (_spotifyToken.expiry > DateTime.now().millisecondsSinceEpoch / 1000) {
+        // access token valid
+        return _spotifyToken.accessToken;
+      } else {
+        // access token invalid, refresh it
+        var newToken =
+            await _refreshSpotifyToken(clientId, _spotifyToken.refreshToken);
+        _spotifyToken = SpotifyToken(
+            accessToken: newToken['access_token'] as String,
+            refreshToken: newToken['refresh_token'] as String,
+            expiry: (DateTime.now().millisecondsSinceEpoch / 1000).round() +
+                (newToken['expires_in'] as int));
+        return _spotifyToken.accessToken;
+      }
+    } else {
+      // new authorization
+      var newToken = await _authorizeSpotify(clientId, redirectUrl);
+      _spotifyToken = SpotifyToken(
+          accessToken: newToken['access_token'] as String,
+          refreshToken: newToken['refresh_token'] as String,
+          expiry: (DateTime.now().millisecondsSinceEpoch / 1000).round() +
+              (newToken['expires_in'] as int));
+      return _spotifyToken.accessToken;
     }
-
-    if (clientId == null) {
-      clientId = cachedClientId;
-    }
-    if (redirectUrl == null) {
-      redirectUrl = cachedRedirectUrl;
-    }
-    var newToken = await _authenticateSpotify(clientId, redirectUrl);
-    _spotifyToken =
-        SpotifyToken(newToken, DateTime.now().millisecondsSinceEpoch + 3600000);
-    return _spotifyToken.token;
   }
 
   /// Authenticates the user and returns the access token on success.
-  Future<String> _authenticateSpotify(
-      String clientId, String redirectUrl) async {
+  Future<dynamic> _authorizeSpotify(String clientId, String redirectUrl) async {
     if (clientId?.isNotEmpty == true && redirectUrl?.isNotEmpty == true) {
-      var scopes = authenticationScopes.join(' ');
-      var authUrl =
-          'https://accounts.spotify.com/authorize?client_id=$clientId&response_type=token&scope=$scopes&redirect_uri=$redirectUrl';
+      // creating auth uri
+      var codeVerifier = _createCodeVerifier();
+      var codeChallenge = _createCodeChallenge(codeVerifier);
+      var state = _createAuthState();
 
-      var authPopup = window.open(authUrl, "Spotify Authorization");
-      String hash;
-      String error;
+      var scopes = authenticationScopes.join(' ');
+      var authorizationUri =
+          'https://accounts.spotify.com/authorize?client_id=$clientId&response_type=code&redirect_uri=$redirectUrl&code_challenge_method=S256&code_challenge=$codeChallenge&state=$state&scope=$scopes';
+
+      // opening auth window
+      var authPopup = window.open(authorizationUri, "Spotify Authorization");
+      String message;
       var sub = window.onMessage.listen(allowInterop((event) {
-        var message = event.data.toString();
-        if (message.startsWith('#')) {
-          log('Hash received: ${event.data}');
-          hash = message;
-        } else if (message.startsWith('?')) {
-          log('Authorization error: ${event.data}');
-          error = message;
-        }
+        message = event.data.toString();
       }));
 
       // loop and wait for auth
-      while (authPopup.closed == false && hash == null && error == null) {
+      while (authPopup.closed == false && message == null) {
         // await response from the window
         await Future.delayed(Duration(milliseconds: 250));
       }
 
-      // cleanup
+      // parse the returned parameters
+      var parsedMessage = Uri.parse(message);
+
+      // check if state is the same
+      if (state != parsedMessage.queryParameters['state']) {
+        throw PlatformException(
+            message: "Invalid state", code: "Authentication Error");
+      }
+
+      // check for error
+      if (parsedMessage.queryParameters['error'] != null ||
+          parsedMessage.queryParameters['code'] == null) {
+        throw PlatformException(
+            message: "${parsedMessage.queryParameters['error']}",
+            code: "Authentication Error");
+      }
+
+      // close auth window
       if (authPopup.closed == false) {
         authPopup.close();
       }
       await sub.cancel();
 
-      // check output
-      if (error != null || hash == null) {
+      // exchange auth code for access and refresh tokens
+      var response =
+          await _authDio.post('https://accounts.spotify.com/api/token',
+              data: {
+                'client_id': clientId,
+                'grant_type': 'authorization_code',
+                'code': parsedMessage.queryParameters['code'],
+                'redirect_uri': redirectUrl,
+                'code_verifier': codeVerifier
+              },
+              options: Options(contentType: Headers.formUrlEncodedContentType));
+
+      if (response.statusCode == 200) {
+        return response.data;
+      } else {
         throw PlatformException(
-            message: "$error", code: "Authentication Error");
+            message: "Token exchange failed", code: "Authentication Error");
       }
-      return hash.split('&')[0].split('=')[1];
     } else {
       throw PlatformException(
           message:
               "Client id or redirectUrl are not set or have invalid format",
           code: "Authentication Error");
     }
+  }
+
+  /// Refreshes the Spotify access token using the refresh token.
+  Future<dynamic> _refreshSpotifyToken(
+      String clientId, String refreshToken) async {
+    var response = await _authDio.post('https://accounts.spotify.com/api/token',
+        data: {
+          'grant_type': 'refresh_token',
+          'refresh_token': refreshToken,
+          'client_id': clientId,
+        },
+        options: Options(contentType: Headers.formUrlEncodedContentType));
+
+    if (response.statusCode == 200) {
+      return response.data;
+    } else {
+      throw PlatformException(
+          message: "Token exchange failed", code: "Authentication Error");
+    }
+  }
+
+  /// Creates a code verifier as per
+  /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
+  String _createCodeVerifier() {
+    return _createRandomString(127);
+  }
+
+  /// Creates a code challenge as per
+  /// https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
+  String _createCodeChallenge(String codeVerifier) {
+    return base64Url
+        .encode(sha256.convert(ascii.encode(codeVerifier)).bytes)
+        .replaceAll("=", "");
+  }
+
+  /// Creates a random string unique to a given authentication session.
+  String _createAuthState() {
+    return _createRandomString(64);
+  }
+
+  /// Creates a cryptographically random string.
+  String _createRandomString(int length) {
+    const _chars =
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+    return List.generate(
+        128, (i) => _chars[math.Random.secure().nextInt(_chars.length)]).join();
   }
 
   /// Starts track playback on the device.
@@ -837,12 +919,15 @@ class WebPlaybackError {
 
 /// Spotify token object.
 class SpotifyToken {
-  /// Spotify token data.
-  final String token;
+  /// Access token data.
+  final String accessToken;
 
-  /// Token expiry time in unix time.
+  /// Refresh token data.
+  final String refreshToken;
+
+  /// Token expiry time in unix seconds.
   final int expiry;
 
   // ignore: public_member_api_docs
-  SpotifyToken(this.token, this.expiry);
+  SpotifyToken({this.accessToken, this.refreshToken, this.expiry});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   dio: ^3.0.10
   json_annotation: ^3.0.0
   js: ^0.6.2
+  crypto: ^2.1.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Replaced the Implicit Grant authorization flow with the new [Authorization Code With PKCE authorization flow](https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce). This allows the plugin to automatically refresh the authorization in the background every time the access token expires, instead of having to open the authorization prompt each time like before. 
This requires a change to the web authentication redirect setup, therefore I updated the README with the new instructions.