### PR TITLE
Added ignore rule for unsafe html

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,9 @@ include: package:pedantic/analysis_options.yaml
 analyzer:
   exclude:
     # Ignore generated files
-    - '**/*.g.dart'
-    - 'lib/generated/**'
-    - 'lib/models/**'
+    - "**/*.g.dart"
+    - "lib/generated/**"
+    - "lib/models/**"
+linter:
+  rules:
+    unsafe_html: false


### PR DESCRIPTION
Added ignore rule for unsafe html, as it should not be an issue for our use case.

As its meant really as an info prompt for the devs to be aware that they should not use user input to modify the HTML dom. 

There were a few open issues related to this warning, see: https://github.com/dart-lang/linter/issues/2348 & https://github.com/dart-lang/linter/issues/1604

