### PR TITLE
Fix a web player disconnection bug

### DIFF
--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -343,7 +343,7 @@ class SpotifySdkPlugin {
 
     // emit not connected event
     connectionStatusEventController.add(jsonEncode(ConnectionStatus(
-            'Spotify SDK disconnected', errorCode!, errorDetails!,
+            'Spotify SDK disconnected', errorCode ?? '', errorDetails ?? '',
             connected: false)
         .toJson()));
   }


### PR DESCRIPTION
Fixed a bug where the web player would not dispose correctly when calling the disconnect() method.