### PR TITLE
Fix crash when calling subscribeConnectionStatus (closes #91).

### DIFF
--- a/lib/models/connection_status.dart
+++ b/lib/models/connection_status.dart
@@ -16,13 +16,13 @@ class ConnectionStatus {
   @JsonKey(name: 'message')
   final String message;
   @JsonKey(name: 'errorCode')
-  final String errorCode;
+  final String? errorCode;
   @JsonKey(name: 'errorDetails')
-  final String errorDetails;
+  final String? errorDetails;
 
   @JsonKey(ignore: true)
   bool hasError() {
-    return errorCode.isNotEmpty == true;
+    return errorCode?.isNotEmpty == true;
   }
 
   factory ConnectionStatus.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/connection_status.g.dart
+++ b/lib/models/connection_status.g.dart
@@ -9,8 +9,8 @@ part of 'connection_status.dart';
 ConnectionStatus _$ConnectionStatusFromJson(Map<String, dynamic> json) {
   return ConnectionStatus(
     json['message'] as String,
-    json['errorCode'] as String,
-    json['errorDetails'] as String,
+    json['errorCode'] as String?,
+    json['errorDetails'] as String?,
     connected: json['connected'] as bool,
   );
 }


### PR DESCRIPTION
This resolves issue https://github.com/brim-borium/spotify_sdk/issues/91.

# Checklist
[x] Verify bug no longer occurs using the repro steps mentioned in the ticket.
[x] Run `dartfmt`.
[x] Run `flutter analyze`

Note: I'm not sure if `message` should be nullable; I've left it as non-null since that change was not required for my test case to pass. Happy to switch it to nullable if that's desirable.