### PR TITLE
Fix iOS skipPrevious method.

### DIFF
--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -175,7 +175,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
                 result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            appRemote.playerAPI?.skip(toNext: { (spotifyResult, error) in
+            appRemote.playerAPI?.skip(toPrevious: { (spotifyResult, error) in
                 if let error = error {
                     result(FlutterError(code: "PlayerAPI Error", message: error.localizedDescription, details: nil))
                     return


### PR DESCRIPTION
Call the correct method on iOS when skipping to previous track.