### PR TITLE
web connectToSpotifyRemote optionally uses supplied token instead of prompting for new one

### DIFF
--- a/lib/platform_channels.dart
+++ b/lib/platform_channels.dart
@@ -138,6 +138,12 @@ class ParamNames {
   /// param name for [accessToken]
   static const String accessToken = 'accessToken';
 
+  /// param name for [refreshToken]
+  static const String refreshToken = 'refreshToken';
+
+  /// param name for [expiresIn]
+  static const String expiresIn = 'expiresIn';
+
   /// param name for [asRadio]
   static const String asRadio = 'asRadio';
 

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -60,14 +60,17 @@ class SpotifySdk {
   /// Throws a [PlatformException] if connecting to the remote api failed
   /// Throws a [MissingPluginException] if the method is not implemented on
   /// the native platforms.
-  static Future<bool> connectToSpotifyRemote(
-      {required String clientId,
-      required String redirectUrl,
-      String spotifyUri = '',
-      bool asRadio = false,
-      String? scope,
-      String playerName = 'Spotify SDK',
-      String? accessToken}) async {
+  static Future<bool> connectToSpotifyRemote({
+    required String clientId,
+    required String redirectUrl,
+    String spotifyUri = '',
+    bool asRadio = false,
+    String? scope,
+    String playerName = 'Spotify SDK',
+    String? accessToken,
+    String? refreshToken,
+    int? expiresIn,
+  }) async {
     try {
       return await _channel.invokeMethod(MethodNames.connectToSpotify, {
         ParamNames.clientId: clientId,
@@ -77,6 +80,8 @@ class SpotifySdk {
         ParamNames.scope: scope,
         ParamNames.spotifyUri: spotifyUri,
         ParamNames.asRadio: asRadio,
+        ParamNames.refreshToken: refreshToken,
+        ParamNames.expiresIn: expiresIn,
       });
     } on Exception catch (e) {
       _logException(MethodNames.connectToSpotify, e);

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -148,6 +148,10 @@ class SpotifySdkPlugin {
         var scopes =
             call.arguments[ParamNames.scope] as String? ?? DEFAULT_SCOPES;
 
+        var accessToken = call.arguments[ParamNames.accessToken] as String?;
+        var refreshToken = call.arguments[ParamNames.refreshToken] as String?;
+        var expiresIn = call.arguments[ParamNames.expiresIn] as int?;
+
         // ensure that required arguments are present
         if (clientId == null ||
             clientId.isEmpty ||
@@ -159,9 +163,24 @@ class SpotifySdkPlugin {
               code: 'Authentication Error');
         }
 
-        // get initial token
-        await _authorizeSpotify(
-            clientId: clientId, redirectUrl: redirectUrl, scopes: scopes);
+        if (accessToken == null ||
+            accessToken.isEmpty ||
+            refreshToken == null ||
+            refreshToken.isEmpty ||
+            expiresIn == null ||
+            expiresIn == 0) {
+          // get initial token
+          await _authorizeSpotify(
+              clientId: clientId, redirectUrl: redirectUrl, scopes: scopes);
+        } else {
+          _spotifyToken = SpotifyToken(
+            clientId: clientId,
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiry: (DateTime.now().millisecondsSinceEpoch / 1000).round() +
+                expiresIn,
+          );
+        }
 
         // create player
         _currentPlayer = Player(PlayerOptions(


### PR DESCRIPTION
Currently connectToSpotifyRemote always opens the authorizeSpotify dialog to request a new token. This uses the accessToken parameter, and introduces a refreshToken and expiresIn parameter to specify an existing token for the web playback SDK instead of prompting for a new one.

Fixes #112