### PR TITLE
Web takes optional tokenSwapURL and tokenRefreshURL for Authorization Code (without PKCE) and token swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ On iOS Spotify starts playing music when attempting connection. This is a defaul
 
 Have a look [in the example](example/lib/main.dart) for detailed insights on how you can use this package.
 
+### Token Swap
+
+You can optionally specify "token swap" URLs to manage tokens with a backend service that protects your OAuth client secret. For more information refer to the [Spotify Token Swap and Refresh Guide](https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/)
+
+```dart
+SpotifySdkPlugin.tokenSwapURL = 'https://example.com/api/spotify/token';
+SpotifySdkPlugin.tokenRefreshURL = 'https://example.com/api/spotify/refresh';
+````
+
+On web, this package will perform an Authorization Code (without PKCE) flow, then exchange the code and refresh the token with a backend service you run at the URLs provided.
+
+While the iOS SDK also supports the "token swap", this package does not yet configure the iOS SDK correctly.
+
 ### Api
 
 #### Connecting/Authenticating

--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ SpotifySdkPlugin.tokenRefreshURL = 'https://example.com/api/spotify/refresh';
 
 On web, this package will perform an Authorization Code (without PKCE) flow, then exchange the code and refresh the token with a backend service you run at the URLs provided.
 
-While the iOS SDK also supports the "token swap", this package does not yet configure the iOS SDK correctly.
-
+Token Swap is for now "web only". While the iOS SDK also supports the "token swap", this flow is not yet supported.
 ### Api
 
 #### Connecting/Authenticating


### PR DESCRIPTION
Before, a Web Playback SDK developer could only use the internal in PKCE auth and refresh flow, which seems to always require an auth prompt.

Now, a developer can specify `tokenSwapURL` and `tokenRefreshURL`. If specified the library performs and Authorization Code (without PKCE) flow, and uses the swap and refresh URLs to exchange the code for a token, and to refresh the token respectively.

The token swap pattern is a first-class pattern on iOS, but the same concept applies to the web SDK for Spotify apps that manage access and refresh tokens with a server side component.

https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/