### PR TITLE
web player state track includes relinking URI

### DIFF
--- a/lib/models/track.dart
+++ b/lib/models/track.dart
@@ -15,7 +15,8 @@ class Track {
     this.duration,
     this.imageUri,
     this.name,
-    this.uri, {
+    this.uri,
+    this.linkedFromUri, {
     required this.isEpisode,
     required this.isPodcast,
   });
@@ -33,6 +34,8 @@ class Track {
   final bool isPodcast;
   final String name;
   final String uri;
+  @JsonKey(name: 'linked_from_uri')
+  final String linkedFromUri;
 
   factory Track.fromJson(Map<String, dynamic> json) => _$TrackFromJson(json);
 

--- a/lib/models/track.g.dart
+++ b/lib/models/track.g.dart
@@ -17,6 +17,7 @@ Track _$TrackFromJson(Map<String, dynamic> json) {
     ImageUri.fromJson(json['image_id'] as Map<String, dynamic>),
     json['name'] as String,
     json['uri'] as String,
+    json['linked_from_uri'] as String?,
     isEpisode: json['is_episode'] as bool,
     isPodcast: json['is_podcast'] as bool,
   );
@@ -32,4 +33,5 @@ Map<String, dynamic> _$TrackToJson(Track instance) => <String, dynamic>{
       'is_podcast': instance.isPodcast,
       'name': instance.name,
       'uri': instance.uri,
+      'linked_from_uri': instance.linkedFromUri,
     };

--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -696,6 +696,7 @@ class SpotifySdkPlugin {
               ImageUri(albumRaw.images[0].url),
               trackRaw.name,
               trackRaw.uri,
+              trackRaw.linked_from.uri,
               isEpisode: trackRaw.type == 'episode',
               isPodcast: trackRaw.type == 'episode',
             )
@@ -952,6 +953,8 @@ class WebPlaybackTrack {
   external WebPlaybackAlbum get album;
   // ignore: public_member_api_docs
   external List<WebPlaybackArtist> get artists;
+  // ignore: public_member_api_docs
+  external WebLinkedFrom get linked_from;
 
   // ignore: public_member_api_docs
   external factory WebPlaybackTrack(
@@ -964,7 +967,8 @@ class WebPlaybackTrack {
       // ignore: non_constant_identifier_names
       bool? is_playable,
       WebPlaybackAlbum? album,
-      List<WebPlaybackArtist>? artists});
+      List<WebPlaybackArtist>? artists,
+      WebLinkedFrom? linked_from});
 }
 
 /// Spotify playback album object
@@ -981,6 +985,19 @@ class WebPlaybackAlbum {
   // ignore: public_member_api_docs
   external factory WebPlaybackAlbum(
       {String? uri, String? name, List<WebPlaybackAlbumImage>? images});
+}
+
+/// Spotify playback album object
+@JS()
+@anonymous
+class WebLinkedFrom {
+  // ignore: public_member_api_docs
+  external String get uri;
+  // ignore: public_member_api_docs
+  external String get id;
+
+  // ignore: public_member_api_docs
+  external factory WebLinkedFrom({String? uri, String? id});
 }
 
 /// Spotify artist object


### PR DESCRIPTION
On the web playback SDK, player state events can include track relinking metadata. 

While this is not documented on the [WebPlaybackTrack Object](https://developer.spotify.com/documentation/web-playback-sdk/reference/#object-web-playback-track), track objects sometimes have a `linked_from` object as documented in the [Track Relinking Guide](https://developer.spotify.com/documentation/general/guides/track-relinking-guide/).

This copies the `linked_from.uri` property into `Track.linkedFromUri`.

Fixes #53