### PR TITLE
fix Track from JSON

### DIFF
--- a/lib/models/track.g.dart
+++ b/lib/models/track.g.dart
@@ -17,7 +17,7 @@ Track _$TrackFromJson(Map<String, dynamic> json) {
     ImageUri.fromJson(json['image_id'] as Map<String, dynamic>),
     json['name'] as String,
     json['uri'] as String,
-    json['linked_from_uri'] as String?,
+    json['linked_from_uri'] as String,
     isEpisode: json['is_episode'] as bool,
     isPodcast: json['is_podcast'] as bool,
   );


### PR DESCRIPTION
This fixes a compiler error introduced in #122:

```
.../lib/models/track.g.dart:20:29: Error: The argument type 'String?' can't be assigned to the parameter type 'String'
because 'String?' is nullable and 'String' isn't.
    json['linked_from_uri'] as String?,
                            ^
Failed to compile
```