### PR TITLE
Build web version

### DIFF
--- a/.github/workflows/spotify_sdk.yml
+++ b/.github/workflows/spotify_sdk.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1.4.0
+      - run: cd example
       - name: Install Dependencies
         run: flutter packages get
       - name: Format

--- a/.github/workflows/spotify_sdk.yml
+++ b/.github/workflows/spotify_sdk.yml
@@ -13,5 +13,7 @@ jobs:
         run: flutter format --set-exit-if-changed lib test example
       - name: Analyze
         run: flutter analyze lib test example
+      - name: Build web version
+        run: flutter build web
       - name: Publish dry run
         run: flutter pub publish --dry-run

--- a/.github/workflows/spotify_sdk.yml
+++ b/.github/workflows/spotify_sdk.yml
@@ -13,8 +13,8 @@ jobs:
         run: flutter format --set-exit-if-changed lib test example
       - name: Analyze
         run: flutter analyze lib test example
+      - name: Publish dry run
+        run: flutter pub publish --dry-run
       - run: cd example
       - name: Build web version
         run: flutter build web
-      - name: Publish dry run
-        run: flutter pub publish --dry-run

--- a/.github/workflows/spotify_sdk.yml
+++ b/.github/workflows/spotify_sdk.yml
@@ -7,13 +7,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1.4.0
-      - run: cd example
       - name: Install Dependencies
         run: flutter packages get
       - name: Format
         run: flutter format --set-exit-if-changed lib test example
       - name: Analyze
         run: flutter analyze lib test example
+      - run: cd example
       - name: Build web version
         run: flutter build web
       - name: Publish dry run

--- a/.github/workflows/spotify_sdk.yml
+++ b/.github/workflows/spotify_sdk.yml
@@ -15,6 +15,7 @@ jobs:
         run: flutter analyze lib test example
       - name: Publish dry run
         run: flutter pub publish --dry-run
-      - run: cd example
       - name: Build web version
-        run: flutter build web
+        run: |
+              cd example
+              flutter build web


### PR DESCRIPTION
This will help us catch compilation issues for new PRs. We could build the Android version instead but I believe builds will take longer in that case.