### PR TITLE
Fix Track JSON deserialization

### DIFF
--- a/lib/models/track.dart
+++ b/lib/models/track.dart
@@ -35,7 +35,7 @@ class Track {
   final String name;
   final String uri;
   @JsonKey(name: 'linked_from_uri')
-  final String linkedFromUri;
+  final String? linkedFromUri;
 
   factory Track.fromJson(Map<String, dynamic> json) => _$TrackFromJson(json);
 

--- a/lib/models/track.g.dart
+++ b/lib/models/track.g.dart
@@ -17,7 +17,7 @@ Track _$TrackFromJson(Map<String, dynamic> json) {
     ImageUri.fromJson(json['image_id'] as Map<String, dynamic>),
     json['name'] as String,
     json['uri'] as String,
-    json['linked_from_uri'] as String,
+    json['linked_from_uri'] as String?,
     isEpisode: json['is_episode'] as bool,
     isPodcast: json['is_podcast'] as bool,
   );


### PR DESCRIPTION
Made the `linkedFromUri` field in `Track` nullable (String?), since the field is not present for tracks that have not been relinked. 
This fixes the issue of tracks failing to deserialize when sound null-safety is enabled.