### PR TITLE
Document subscribeConnectionStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Token Swap is for now "web only". While the iOS SDK also supports the "token swa
 |  getAuthenticationToken | Gets the Authentication Token that you can use to work with the [Web Api](https://developer.spotify.com/documentation/web-api/) | ✔ |  ✔ | ✔ |
 |  disconnect | Disconnects the app connection | ✔ |  ✔ | ✔ |
 |  isSpotifyAppActive | Checks if the Spotify app is active. The Spotify app will be considered active if music is playing. | ✔ |  ✔ | 🚧 |
+|  subscribeConnectionStatus | Subscribes to the current player state. | ✔ |  ✔ | 🚧 |
 
 #### Player Api
 
@@ -157,7 +158,7 @@ Token Swap is for now "web only". While the iOS SDK also supports the "token swa
 |  getLibraryState | Gets the current library state | ✔ | ✔ | 🚧 |
 |  removeFromLibrary | Removes the given spotifyUri to the users library | ✔ | ✔ | 🚧 |
 |  subscribeToCapabilities |  Subscribes to the current users capabilities | ✔ | 🚧 | 🚧 |
-|  subscribeToUserStatus |  Subscrives to  the current users status | ✔ | 🚧 | 🚧 |
+|  subscribeToUserStatus |  Subscribes to  the current users status | ✔ | 🚧 | 🚧 |
 
 #### Connect Api
 


### PR DESCRIPTION
I noticed that `subscribeConnectionStatus` was missing from the ReadMe. I also noticed that all the others subscription calls have "to" in their names. @brim-borium would you consider changing `subscribeConnectionStatus` to `subscribeToConnectionStatus` for the sake of consistency? It would be a breaking API change which would call for a major version release.