### PR TITLE
Switch to native Spotify iOS XCFramework

### DIFF
--- a/ios/prepare-iOS-SDK.sh
+++ b/ios/prepare-iOS-SDK.sh
@@ -1,27 +1,10 @@
 #!/bin/sh
+REPO_NAME="ios-sdk"
+FRAMEWORK_NAME="SpotifyiOS.xcframework"
 
-if [ "$#" -eq 1 ]; then
-    BASE_DIR=$1
-else
-BASE_DIR=$(exec pwd)
-fi
-
-rm -fR ios-sdk
-mkdir ios-sdk
-curl -OL https://github.com/spotify/ios-sdk/archive/v1.2.2.zip
-unzip -o v1.2.2.zip
-mv ios-sdk-1.2.2/SpotifyiOS.framework ios-sdk
-rm v1.2.2.zip
-rm -fR ios-sdk-1.2.2
-
-BASE_DIR="${BASE_DIR}/ios-sdk"
-echo "BASE_DIR: ${BASE_DIR}"
-
-MODULE_DIR="${BASE_DIR}/SpotifyiOS.framework"
-echo "MODULE_DIR: ${MODULE_DIR}"
-mkdir -p "${MODULE_DIR}"
-printf "module SpotifyiOS {\n\
-header \"Headers/SpotifyiOS.h\"\n\
-export *\n\
-}" > "${MODULE_DIR}/module.map"
-echo "Created module map."
+#!/bin/sh
+rm -fR ${REPO_NAME}
+mkdir ${REPO_NAME}
+git clone https://github.com/spotify/${REPO_NAME}
+git -C ${REPO_NAME} checkout f9a7d53
+find ./${REPO_NAME} -mindepth 1 -maxdepth 1 -not -name ${FRAMEWORK_NAME} -exec rm -rf '{}' \;   # Keep on only the xcframework folder

--- a/ios/spotify_sdk.podspec
+++ b/ios/spotify_sdk.podspec
@@ -20,7 +20,7 @@ Unofficial Spotify Flutter SDK.
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
   s.swift_version = '5.0'
-  s.preserve_paths = 'ios-sdk/SpotifyiOS.framework'
-  s.vendored_frameworks = 'ios-sdk/SpotifyiOS.framework'
   s.prepare_command = './prepare-iOS-SDK.sh'
+  s.vendored_frameworks = 'ios-sdk/SpotifyiOS.xcframework'
+  s.preserve_paths = 'ios-sdk/SpotifyiOS.xcframework'
   end


### PR DESCRIPTION
Spotify have silently released an `XCFramework` without making a new version release on GitHub. It is just checked out in their repo. I had to change the `prepare-iOS-SDK.sh` script to switch to this new type of framework. In fact now it is even simpler than before.

This PR brings 2 big benefits:
- It is no more needed to manually create a module map as the XCFramework has them bundled in🎉.
- More CPU architectures are now supported. You can use the framework on iOS simulators running on Apple Silicon (ARM64e)🍏

Caveat:
- Git must be installed on dev's machine as it is needed to clone the repo in the script. We could document it in the ReadMe although Flutter requires Git so I don't think it is a real danger. Mac OS does come with Git preinstalled and Windows or Linux users cannot build iOS apps anyway.