### PR TITLE
Fix queue endpoint for web

### DIFF
--- a/lib/spotify_sdk_web.dart
+++ b/lib/spotify_sdk_web.dart
@@ -641,7 +641,7 @@ class SpotifySdkPlugin {
     }
 
     await _dio.post(
-      '/add-to-queue',
+      '/queue',
       queryParameters: {'uri': uri, 'device_id': _currentPlayer!.deviceID},
       options: Options(
         headers: {


### PR DESCRIPTION
Tested with the example code as working.

Before:
```
queueTrack failed with: DioError [DioErrorType.response]: Http status error [502]
```

Now it queues correctly.

See the docs: https://developer.spotify.com/documentation/web-api/reference/#/operations/add-to-queue.