### PR TITLE
Fix null album when getting advertisement on android

### DIFF
--- a/lib/models/album.dart
+++ b/lib/models/album.dart
@@ -6,8 +6,8 @@ part 'album.g.dart';
 class Album {
   Album(this.name, this.uri);
 
-  final String name;
-  final String uri;
+  final String? name;
+  final String? uri;
 
   factory Album.fromJson(Map<String, dynamic> json) => _$AlbumFromJson(json);
 

--- a/lib/models/album.g.dart
+++ b/lib/models/album.g.dart
@@ -7,8 +7,8 @@ part of 'album.dart';
 // **************************************************************************
 
 Album _$AlbumFromJson(Map<String, dynamic> json) => Album(
-      json['name'] as String,
-      json['uri'] as String,
+      json['name'] as String?,
+      json['uri'] as String?,
     );
 
 Map<String, dynamic> _$AlbumToJson(Album instance) => <String, dynamic>{


### PR DESCRIPTION
Getting no updates from stream when there is an advertisement on android ,working fine on IOS
Possible error cause was , 

```
Album _$AlbumFromJson(Map<String, dynamic> json) => Album(
  json['name'] as String,
  json['uri'] as String,
);
```

here these values are non nullable , but android gives null album value in response when there is an advertisement
and because of this , spotify_sdk failed to parse that response into PlayerState model , and we will not get any playerState update

here is a sample of jsonData from nativeAndroid , when advertisement is playing
```
{is_paused: false, playback_options: {shuffle: false, repeat: 0}, playback_position: 89, playback_restrictions: {can_repeat_context: true, can_repeat_track: false, can_seek: false, can_skip_next: false, can_skip_prev: false, can_toggle_shuffle: false}, playback_speed: 1.0, track: {album: {}, artist: {}, artists: [], duration_ms: 29712, image_id: {raw: }, is_episode: false, is_podcast: false, name: Advertisement, uri: spotify:ad:0000000172ade163000000203a9f868d}}
```

So here , we can see that album is an empty array , which breaks the PlayerState model

and here is a sample of normal song
```
{is_paused: false, playback_options: {shuffle: false, repeat: 0}, playback_position: 0, playback_restrictions: {can_repeat_context: true, can_repeat_track: false, can_seek: false, can_skip_next: true, can_skip_prev: false, can_toggle_shuffle: false}, playback_speed: 0.0, track: {album: {name: Clapton Chronicles: The Best of Eric Clapton, uri: spotify:album:6FCakQJ6z6TF0y0qkHYKgy}, artist: {name: Eric Clapton, uri: spotify:artist:6PAt558ZEZl0DmdXlnjMgD}, artists: [{name: Eric Clapton, uri: spotify:artist:6PAt558ZEZl0DmdXlnjMgD}], duration_ms: 260000, image_id: {raw: spotify:image:ab67616d0000b2734e36eb543ce3731ac913845c}, is_episode: false, is_podcast: false, name: Layla - Acoustic; Live at MTV Unplugged, Bray Film Studios, Windsor, England, UK, 1/16/1992; 1999 Remaster, uri: spotify:track:6YEOmCsXSk9ZPE0FkcCiuQ}}
```


