### PR TITLE
Bump native iOS SDK to 1.2.4

### DIFF
--- a/ios/prepare-iOS-SDK.sh
+++ b/ios/prepare-iOS-SDK.sh
@@ -6,5 +6,5 @@ FRAMEWORK_NAME="SpotifyiOS.xcframework"
 rm -fR ${REPO_NAME}
 mkdir ${REPO_NAME}
 git clone https://github.com/spotify/${REPO_NAME}
-git -C ${REPO_NAME} checkout f9a7d53
+git -C ${REPO_NAME} checkout cdbdcb3
 find ./${REPO_NAME} -mindepth 1 -maxdepth 1 -not -name ${FRAMEWORK_NAME} -exec rm -rf '{}' \;   # Keep on only the xcframework folder


### PR DESCRIPTION
Native iOS SDK 1.2.4 was released. Just changing the commit ID in the download script is enough.