### PR TITLE
update Spotify iOS SDK to v2.1.7

### DIFF
--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -366,11 +366,13 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
         if accessToken != nil {
             appRemote?.connect()
         } else {
+          let appRemote = self.appRemote
+          Task {
             // Note: A blank string will play the user's last song or pick a random one.
-            if self.appRemote?.authorizeAndPlayURI(spotifyUri, asRadio: asRadio ?? false, additionalScopes: scopes) == false {
-                throw SpotifyError.spotifyNotInstalledError
+            if await appRemote?.authorizeAndPlayURI(spotifyUri, asRadio: asRadio ?? false, additionalScopes: scopes) == false {
+              throw SpotifyError.spotifyNotInstalledError
             }
-        }
+          }
     }
 }
 

--- a/ios/prepare-iOS-SDK.sh
+++ b/ios/prepare-iOS-SDK.sh
@@ -6,5 +6,5 @@ FRAMEWORK_NAME="SpotifyiOS.xcframework"
 rm -fR ${REPO_NAME}
 mkdir ${REPO_NAME}
 git clone https://github.com/spotify/${REPO_NAME}
-git -C ${REPO_NAME} checkout cdbdcb3
+git -C ${REPO_NAME} checkout checkout tags/v2.1.7
 find ./${REPO_NAME} -mindepth 1 -maxdepth 1 -not -name ${FRAMEWORK_NAME} -exec rm -rf '{}' \;   # Keep on only the xcframework folder


### PR DESCRIPTION
previous version unable to launch Spotify on iOS 18 because of deprecated `UIApplication.openURL(_:)`.

New Spotify SDK version:
https://github.com/spotify/ios-sdk/releases/tag/v2.1.7

![Screenshot 2024-09-25 at 18 06 13](https://github.com/user-attachments/assets/1cd62996-baeb-413d-b0c9-0de4db1369f0)
