### PR TITLE
fix: deep linking on iOS

### DIFF
--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -390,7 +390,7 @@ extension SwiftSpotifySdkPlugin {
         }
 
         setAccessTokenFromURL(url: url)
-        return true
+        return false
     }
 
     private func setAccessTokenFromURL(url: URL) {


### PR DESCRIPTION
Our app stopped receiving deep link URLs after adding `spotify_sdk` package.

Looks like a problem in the `application(_:continue:restorationHandler:)` callback: according to [Apple's docs](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/application(_:continue:restorationhandler:)#return-value) returning `true` from this method prevents activity information going further, indicating that activity already recreated in this handler.

With applied fix, the deep links works as before.