### PR TITLE
Support getting a Swap Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,13 @@ On web, this package will perform an Authorization Code (without PKCE) flow, the
 
 #### Mobile setup
 
-For iOS setup: Add a `SpotifySDKCallbackURL` to your Info.plist file. This allows the SDK to launch your app after receiving authentication from the Spotify app.
+For iOS setup: Add a `SpotifySDKCallbackURL` and `LSApplicationQueriesSchemes` to your Info.plist file. This allows the SDK to search for the Spotify app and launch your app after receiving authentication from the Spotify app.
 
 ```swift
+  <key>LSApplicationQueriesSchemes</key>
+    <array>
+      <string>spotify</string>
+  </array>
   <key>SpotifySDKCallbackURL</key>
   <string>example://auth/callback</string>
 ```

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Have a look [in the example](example/lib/main.dart) for detailed insights on how
 
 You can optionally specify "token swap" URLs to manage tokens with a backend service that protects your OAuth client secret. For more information refer to the [Spotify Token Swap and Refresh Guide](https://developer.spotify.com/documentation/ios/guides/token-swap-and-refresh/)
 
+#### Web setup
+
 ```dart
 SpotifySdkPlugin.tokenSwapURL = 'https://example.com/api/spotify/token';
 SpotifySdkPlugin.tokenRefreshURL = 'https://example.com/api/spotify/refresh';
@@ -155,7 +157,28 @@ SpotifySdkPlugin.tokenRefreshURL = 'https://example.com/api/spotify/refresh';
 
 On web, this package will perform an Authorization Code (without PKCE) flow, then exchange the code and refresh the token with a backend service you run at the URLs provided.
 
-Token Swap is for now "web only". While the iOS SDK also supports the "token swap", this flow is not yet supported.
+#### Mobile setup
+
+Currently is only supported on iOS.
+
+You have two options for token swap handling:
+
+1. Let the SDK handle the token swap exchange automatically
+2. Handle the token swap process yourself outside of the SDK
+
+If you choose to handle the token swap yourself, set the `tokenRefreshUrl` parameter to `null`. This will cause the function to return the swap token directly.
+
+For iOS setup: Add a `CFBundleURLScheme` to your Info.plist file. This allows the SDK to launch your app after receiving authentication from the Spotify app. The SDK will use the first URL scheme it finds in your app's Info.plist.
+
+```dart
+SpotifySdk.connectToSpotifyTokenSwap(
+  clientId: "",
+  redirectUri: "example://spotify-auth/callback",
+  scopes: "app-remote-control,user-modify-playback-state,playlist-read-private",
+  tokenSwapUrl: "https://example.com/api/spotify/swap",
+  tokenRefreshUrl: "https://example.com/api/spotify/refresh",
+);
+```
 
 ### Api
 
@@ -164,6 +187,7 @@ Token Swap is for now "web only". While the iOS SDK also supports the "token swa
 | Function  | Description| Android | iOS | Web |
 |---|---|---|---|---|
 | connectToSpotifyRemote  | Connects the App to Spotify | ✔ | ✔ | ✔ |
+| connectToSpotifyTokenSwap  | Connects the App to Spotify using Token Swap | 🚧 | ✔ | ❌ |
 |  getAccessToken | Gets the Access Token that you can use to work with the [Web Api](https://developer.spotify.com/documentation/web-api/) | ✔ |  ✔ | ✔ |
 |  disconnect | Disconnects the app connection | ✔ |  ✔ | ✔ |
 |  subscribeConnectionStatus | Subscribes to the current player state. | ✔ |  ✔ | 🚧 |

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ SpotifySdk.getSwapToken(
 );
 ```
 
+Check the [Spotify docs](https://developer.spotify.com/documentation/ios/concepts/token-swap-and-refresh) for how to setup the tokenSwapUrl.
+
 ### Api
 
 #### Connecting/Authenticating

--- a/README.md
+++ b/README.md
@@ -159,24 +159,23 @@ On web, this package will perform an Authorization Code (without PKCE) flow, the
 
 #### Mobile setup
 
-Currently is only supported on iOS.
-
-You have two options for token swap handling:
-
-1. Let the SDK handle the token swap exchange automatically
-2. Handle the token swap process yourself outside of the SDK
-
 If you choose to handle the token swap yourself, set the `tokenRefreshUrl` parameter to `null`. This will cause the function to return the swap token directly.
 
-For iOS setup: Add a `CFBundleURLScheme` to your Info.plist file. This allows the SDK to launch your app after receiving authentication from the Spotify app. The SDK will use the first URL scheme it finds in your app's Info.plist.
+For iOS setup: Add a `SpotifySDKCallbackURL` to your Info.plist file. This allows the SDK to launch your app after receiving authentication from the Spotify app.
+
+```swift
+  <key>SpotifySDKCallbackURL</key>
+  <string>example://auth/callback</string>
+```
+
+Dart code:
 
 ```dart
-SpotifySdk.connectToSpotifyTokenSwap(
+SpotifySdk.getSwapToken(
   clientId: "",
   redirectUri: "example://auth/spotify/callback",
   scopes: "app-remote-control,user-modify-playback-state,playlist-read-private",
   tokenSwapUrl: "https://example.com/api/spotify/swap",
-  tokenRefreshUrl: "https://example.com/api/spotify/refresh",
 );
 ```
 
@@ -187,7 +186,7 @@ SpotifySdk.connectToSpotifyTokenSwap(
 | Function  | Description| Android | iOS | Web |
 |---|---|---|---|---|
 | connectToSpotifyRemote  | Connects the App to Spotify | ✔ | ✔ | ✔ |
-| connectToSpotifyTokenSwap  | Connects the App to Spotify using Token Swap | 🚧 | ✔ | ❌ |
+| getSwapToken  | Get's the Swap Token from the Spotify app | ✔ | ✔ | ❌ |
 |  getAccessToken | Gets the Access Token that you can use to work with the [Web Api](https://developer.spotify.com/documentation/web-api/) | ✔ |  ✔ | ✔ |
 |  disconnect | Disconnects the app connection | ✔ |  ✔ | ✔ |
 |  subscribeConnectionStatus | Subscribes to the current player state. | ✔ |  ✔ | 🚧 |

--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ On web, this package will perform an Authorization Code (without PKCE) flow, the
 
 #### Mobile setup
 
-If you choose to handle the token swap yourself, set the `tokenRefreshUrl` parameter to `null`. This will cause the function to return the swap token directly.
-
 For iOS setup: Add a `SpotifySDKCallbackURL` to your Info.plist file. This allows the SDK to launch your app after receiving authentication from the Spotify app.
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ On web, this package will perform an Authorization Code (without PKCE) flow, the
 
 #### Mobile setup
 
+* Note: Mobile implementation currently is only for getting the Swap token to exchange for a real token. It will not authenticate the SpotifySdk's other functions.
+
 For iOS setup: Add a `SpotifySDKCallbackURL` and `LSApplicationQueriesSchemes` to your Info.plist file. This allows the SDK to search for the Spotify app and launch your app after receiving authentication from the Spotify app.
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ For iOS setup: Add a `CFBundleURLScheme` to your Info.plist file. This allows th
 ```dart
 SpotifySdk.connectToSpotifyTokenSwap(
   clientId: "",
-  redirectUri: "example://spotify-auth/callback",
+  redirectUri: "example://auth/spotify/callback",
   scopes: "app-remote-control,user-modify-playback-state,playlist-read-private",
   tokenSwapUrl: "https://example.com/api/spotify/swap",
   tokenRefreshUrl: "https://example.com/api/spotify/refresh",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     // -- spotify
-    implementation "com.spotify.android:auth:2.1.0"
+    implementation "com.spotify.android:auth:2.1.2"
     implementation project(':spotify-app-remote')
     implementation 'com.google.code.gson:gson:2.10.1'
     // -- events

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
+        <!-- Spotify SDK Authentication Activities -->
+        <activity
+            android:exported="true"
+            android:name="com.spotify.sdk.android.authentication.AuthCallbackActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name="com.spotify.sdk.android.authentication.LoginActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -184,7 +184,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
             methodGetSwapToken -> getSwapToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScope), call.argument(paramTokenSwapUrl), result)
             methodGetAccessToken -> getAccessToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScope), result)
             methodDisconnectFromSpotify -> disconnectFromSpotify(result)
-            methodIsSpotifyInstalled -> isSpotifyInstalled()
+            methodIsSpotifyInstalled -> isSpotifyInstalled(result)
             //connectApi calls
             methodSwitchToLocalDevice -> spotifyConnectApi?.switchToLocalDevice()
             //playerApi calls
@@ -341,7 +341,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
             }
 
             // Check Spotify installation
-            if (!isSpotifyInstalled()) {
+            if (!_isSpotifyInstalled()) {
                 result.error("SPOTIFY_NOT_INSTALLED", "Spotify is not installed", null)
                 return
             }
@@ -447,9 +447,32 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
         pendingOperation = PendingOperation(this, result)
     }
 
-    private fun isSpotifyInstalled(): Boolean {
+    private fun isSpotifyInstalled(result: Result) {
+        try {
+            if (applicationActivity == null) {
+                result.error(
+                    "NO_ACTIVITY", 
+                    "Activity is not attached", 
+                    null
+                )
+                return
+            }
+            
+            val isInstalled = _isSpotifyInstalled()
+            
+            result.success(isInstalled)
+        } catch (e: Exception) {
+            result.error(
+                "SPOTIFY_CHECK_FAILED",
+                "Failed to check if Spotify is installed",
+                e.toString()
+            )
+        }
+    }
+
+    private fun _isSpotifyInstalled(): Boolean {
         return try {
-            applicationActivity?.packageManager?.getPackageInfo("com.spotify.music", 0)
+            applicationActivity!!.packageManager.getPackageInfo("com.spotify.music", 0)
             true
         } catch (e: PackageManager.NameNotFoundException) {
             false

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -9,9 +9,6 @@ import com.spotify.android.appremote.api.Connector.ConnectionListener
 import com.spotify.android.appremote.api.SpotifyAppRemote
 import com.spotify.android.appremote.api.error.*
 import com.spotify.sdk.android.auth.*
-import com.spotify.sdk.android.auth.AuthorizationClient
-import com.spotify.sdk.android.auth.AuthorizationRequest
-import com.spotify.sdk.android.auth.AuthorizationResponse
 import de.minimalme.spotify_sdk.subscriptions.*
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -8,6 +8,7 @@ import com.spotify.android.appremote.api.ConnectionParams
 import com.spotify.android.appremote.api.Connector.ConnectionListener
 import com.spotify.android.appremote.api.SpotifyAppRemote
 import com.spotify.android.appremote.api.error.*
+import com.spotify.sdk.android.auth.*
 import com.spotify.sdk.android.auth.AuthorizationClient
 import com.spotify.sdk.android.auth.AuthorizationRequest
 import com.spotify.sdk.android.auth.AuthorizationResponse
@@ -50,6 +51,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
 
     //connecting
     private val methodConnectToSpotify = "connectToSpotify"
+    private val methodGetSwapToken = "getSwapToken"
     private val methodGetAccessToken = "getAccessToken"
     private val methodDisconnectFromSpotify = "disconnectFromSpotify"
 
@@ -86,6 +88,8 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
     private val paramClientId = "clientId"
     private val paramRedirectUrl = "redirectUrl"
     private val paramScope = "scope"
+    private val paramScopes = "scopes"
+    private val paramTokenSwapUrl = "tokenSwapUrl"
     private val paramSpotifyUri = "spotifyUri"
     private val paramImageUri = "imageUri"
     private val paramImageDimension = "imageDimension"
@@ -175,6 +179,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
         when (call.method) {
             //connecting to spotify
             methodConnectToSpotify -> connectToSpotify(call.argument(paramClientId), call.argument(paramRedirectUrl), result)
+            methodGetSwapToken -> getSwapToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScope), call.argument(paramTokenSwapUrl), result)
             methodGetAccessToken -> getAccessToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScope), result)
             methodDisconnectFromSpotify -> disconnectFromSpotify(result)
             //connectApi calls
@@ -305,6 +310,21 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
         }
     }
 
+    private fun getSwapToken(clientId: String?, redirectUrl: String?, scopes: String?, tokenSwapUrl: String?, result: Result) {
+        if (clientId == null || redirectUrl == null || scope == null) {
+            result.error("INVALID_ARGUMENTS", "Missing required arguments", null)
+            return
+        }
+
+        if (!isSpotifyInstalled()) {
+            result.error("SPOTIFY_NOT_INSTALLED", "Spotify is not installed", null)
+            return
+        }
+
+        _authenticateTokenSwap(clientId, redirectUrl, scopes, result)
+        
+    }
+
     private fun getAccessToken(clientId: String?, redirectUrl: String?, scope: String?, result: Result) {
         if (applicationActivity == null) {
             throw IllegalStateException("getAccessToken needs a foreground activity")
@@ -363,6 +383,9 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
             AuthorizationResponse.Type.TOKEN -> {
                 result.success(response.accessToken)
             }
+            AuthorizationResponse.Type.CODE -> {
+                result.success(response.code)
+            }
             AuthorizationResponse.Type.ERROR -> result.error(errorAuthenticationToken, "Authentication went wrong", response.error)
             else -> result.notImplemented()
         }
@@ -375,6 +398,40 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
             "Concurrent operations detected: " + pendingOperation?.method.toString() + ", " + this
         }
         pendingOperation = PendingOperation(this, result)
+    }
+
+    private fun isSpotifyInstalled(): Boolean {
+        return try {
+            activity?.packageManager?.getPackageInfo("com.spotify.music", 0)
+            true
+        } catch (e: PackageManager.NameNotFoundException) {
+            false
+        }
+    }
+
+    private fun _authenticateTokenSwap(
+        clientId: String,
+        redirectUri: String,
+        scopes: String,
+        result: MethodChannel.Result
+    ) {
+
+        if (activity == null) {
+            result.error("NO_ACTIVITY", "Activity is not attached", null)
+            return
+        }
+
+        val builder = AuthorizationRequest.Builder(
+            clientId,
+            AuthorizationResponse.Type.CODE,
+            redirectUri
+        )
+
+        builder.setScopes(scopes.split(",").toTypedArray())
+        builder.setShowDialog(true)
+        val request = builder.build()
+
+        AuthorizationClient.openLoginActivity(activity, REQUEST_CODE, request)
     }
 }
 

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import android.content.pm.PackageManager
+import android.webkit.URLUtil
 import com.spotify.android.appremote.api.ConnectionParams
 import com.spotify.android.appremote.api.Connector.ConnectionListener
 import com.spotify.android.appremote.api.SpotifyAppRemote
@@ -34,6 +35,8 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
     private val channelName = "spotify_sdk"
     private val loggingTag = "spotify_sdk"
 
+    private val REQUEST_SWAP_CODE = 1337
+
     // event channels
     private var playerContextChannel : EventChannel? = null
     private var playerStateChannel : EventChannel? = null
@@ -52,6 +55,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
     private val methodGetSwapToken = "getSwapToken"
     private val methodGetAccessToken = "getAccessToken"
     private val methodDisconnectFromSpotify = "disconnectFromSpotify"
+    private val methodIsSpotifyInstalled = "isSpotifyInstalled"
 
     // connectApi
     private val methodSwitchToLocalDevice = "switchToLocalDevice"
@@ -180,6 +184,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
             methodGetSwapToken -> getSwapToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScope), call.argument(paramTokenSwapUrl), result)
             methodGetAccessToken -> getAccessToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScope), result)
             methodDisconnectFromSpotify -> disconnectFromSpotify(result)
+            methodIsSpotifyInstalled -> isSpotifyInstalled()
             //connectApi calls
             methodSwitchToLocalDevice -> spotifyConnectApi?.switchToLocalDevice()
             //playerApi calls
@@ -207,6 +212,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
             //imageApi calls
             methodGetImage -> spotifyImagesApi?.getImage(call.argument(paramImageUri), call.argument(paramImageDimension))
             // method call is not implemented yet
+
             else -> result.notImplemented()
         }
     }
@@ -308,33 +314,62 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
         }
     }
 
-    private fun getSwapToken(clientId: String?, redirectUrl: String?, scopes: String?, tokenSwapUrl: String?, result: Result) {
-        if (clientId == null || redirectUrl == null || scopes == null) {
-            result.error("INVALID_ARGUMENTS", "Missing required arguments", null)
-            return
+    /**
+     * Gets a swap token from Spotify using token swap authentication.
+     * 
+     * @param clientId The Spotify client ID
+     * @param redirectUrl The redirect URL registered in Spotify dashboard
+     * @param scopes Comma-separated list of Spotify authorization scopes
+     * @param tokenSwapUrl URL for token swap endpoint
+     * @param result Flutter result callback
+     */
+    private fun getSwapToken(
+        clientId: String?,
+        redirectUrl: String?,
+        scopes: String?,
+        tokenSwapUrl: String?,
+        result: Result
+    ) {
+        try {
+            // Validate required parameters
+            when {
+                clientId.isNullOrBlank() -> throw IllegalArgumentException("Client ID is required")
+                redirectUrl.isNullOrBlank() -> throw IllegalArgumentException("Redirect URL is required")
+                scopes.isNullOrBlank() -> throw IllegalArgumentException("Scopes are required")
+                tokenSwapUrl.isNullOrBlank() -> throw IllegalArgumentException("Token swap URL is required")
+                !URLUtil.isValidUrl(tokenSwapUrl) -> throw IllegalArgumentException("Invalid token swap URL")
+            }
+
+            // Check Spotify installation
+            if (!isSpotifyInstalled()) {
+                result.error("SPOTIFY_NOT_INSTALLED", "Spotify is not installed", null)
+                return
+            }
+
+            // Verify activity exists
+            val activity = applicationActivity ?: run {
+                result.error("NO_ACTIVITY", "Activity is not attached", null)
+                return
+            }
+
+            // Store pending operation
+            methodGetSwapToken.checkAndSetPendingOperation(result)
+
+            // Build authorization request
+            val request = AuthorizationRequest.Builder(
+                clientId,
+                AuthorizationResponse.Type.CODE,
+                redirectUrl
+            ).apply {
+                setScopes(scopes.split(",").toTypedArray())
+                setShowDialog(true)
+            }.build()
+
+            // Start authentication
+            AuthorizationClient.openLoginActivity(activity, REQUEST_SWAP_CODE, request)
+        } catch (e: Exception) {
+            result.error("AUTH_ERROR", e.message, e.toString())
         }
-
-        if (!isSpotifyInstalled()) {
-            result.error("SPOTIFY_NOT_INSTALLED", "Spotify is not installed", null)
-            return
-        }
-
-        if (applicationActivity == null) {
-            result.error("NO_ACTIVITY", "Activity is not attached", null)
-            return
-        }
-
-        val builder = AuthorizationRequest.Builder(
-            clientId,
-            AuthorizationResponse.Type.CODE,
-            redirectUrl
-        )
-
-        builder.setScopes(scopes.split(",").toTypedArray())
-        builder.setShowDialog(true)
-        val request = builder.build()
-
-        AuthorizationClient.openLoginActivity(applicationActivity, 1337, request)
     }
 
     private fun getAccessToken(clientId: String?, redirectUrl: String?, scope: String?, result: Result) {

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -181,7 +181,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
         when (call.method) {
             //connecting to spotify
             methodConnectToSpotify -> connectToSpotify(call.argument(paramClientId), call.argument(paramRedirectUrl), result)
-            methodGetSwapToken -> getSwapToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScope), call.argument(paramTokenSwapUrl), result)
+            methodGetSwapToken -> getSwapToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScopes), call.argument(paramTokenSwapUrl), result)
             methodGetAccessToken -> getAccessToken(call.argument(paramClientId), call.argument(paramRedirectUrl), call.argument(paramScope), result)
             methodDisconnectFromSpotify -> disconnectFromSpotify(result)
             methodIsSpotifyInstalled -> isSpotifyInstalled(result)

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -321,8 +321,22 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
             return
         }
 
-        _authenticateTokenSwap(clientId, redirectUrl, scopes, result)
-        
+        if (activity == null) {
+            result.error("NO_ACTIVITY", "Activity is not attached", null)
+            return
+        }
+
+        val builder = AuthorizationRequest.Builder(
+            clientId,
+            AuthorizationResponse.Type.CODE,
+            redirectUri
+        )
+
+        builder.setScopes(scopes.split(",").toTypedArray())
+        builder.setShowDialog(true)
+        val request = builder.build()
+
+        AuthorizationClient.openLoginActivity(activity, REQUEST_CODE, request)
     }
 
     private fun getAccessToken(clientId: String?, redirectUrl: String?, scope: String?, result: Result) {
@@ -407,31 +421,6 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
         } catch (e: PackageManager.NameNotFoundException) {
             false
         }
-    }
-
-    private fun _authenticateTokenSwap(
-        clientId: String,
-        redirectUri: String,
-        scopes: String,
-        result: MethodChannel.Result
-    ) {
-
-        if (activity == null) {
-            result.error("NO_ACTIVITY", "Activity is not attached", null)
-            return
-        }
-
-        val builder = AuthorizationRequest.Builder(
-            clientId,
-            AuthorizationResponse.Type.CODE,
-            redirectUri
-        )
-
-        builder.setScopes(scopes.split(",").toTypedArray())
-        builder.setShowDialog(true)
-        val request = builder.build()
-
-        AuthorizationClient.openLoginActivity(activity, REQUEST_CODE, request)
     }
 }
 

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -308,7 +308,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
     }
 
     private fun getSwapToken(clientId: String?, redirectUrl: String?, scopes: String?, tokenSwapUrl: String?, result: Result) {
-        if (clientId == null || redirectUrl == null || scope == null) {
+        if (clientId == null || redirectUrl == null || scopes == null) {
             result.error("INVALID_ARGUMENTS", "Missing required arguments", null)
             return
         }
@@ -318,7 +318,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
             return
         }
 
-        if (activity == null) {
+        if (applicationActivity == null) {
             result.error("NO_ACTIVITY", "Activity is not attached", null)
             return
         }
@@ -326,14 +326,14 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
         val builder = AuthorizationRequest.Builder(
             clientId,
             AuthorizationResponse.Type.CODE,
-            redirectUri
+            redirectUrl
         )
 
         builder.setScopes(scopes.split(",").toTypedArray())
         builder.setShowDialog(true)
         val request = builder.build()
 
-        AuthorizationClient.openLoginActivity(activity, REQUEST_CODE, request)
+        AuthorizationClient.openLoginActivity(applicationActivity, 1337, request)
     }
 
     private fun getAccessToken(clientId: String?, redirectUrl: String?, scope: String?, result: Result) {
@@ -413,7 +413,7 @@ class SpotifySdkPlugin : MethodCallHandler, FlutterPlugin, ActivityAware, Plugin
 
     private fun isSpotifyInstalled(): Boolean {
         return try {
-            activity?.packageManager?.getPackageInfo("com.spotify.music", 0)
+            applicationActivity?.packageManager?.getPackageInfo("com.spotify.music", 0)
             true
         } catch (e: PackageManager.NameNotFoundException) {
             false

--- a/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
+++ b/android/src/main/kotlin/de/minimalme/spotify_sdk/SpotifySdkPlugin.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import android.content.pm.PackageManager
 import com.spotify.android.appremote.api.ConnectionParams
 import com.spotify.android.appremote.api.Connector.ConnectionListener
 import com.spotify.android.appremote.api.SpotifyAppRemote

--- a/ios/Classes/SpotifySdkConstants.swift
+++ b/ios/Classes/SpotifySdkConstants.swift
@@ -4,7 +4,7 @@ public class SpotifySdkConstants
 {
     //connecting
     public static let methodConnectToSpotify = "connectToSpotify"
-    public static let methodConnectToSpotifyTokenSwap = "connectToSpotifyTokenSwap"
+    public static let methodGetSwapToken = "getSwapToken"
     public static let methodGetAccessToken = "getAccessToken"
     public static let methodDisconnectFromSpotify = "disconnectFromSpotify"
 

--- a/ios/Classes/SpotifySdkConstants.swift
+++ b/ios/Classes/SpotifySdkConstants.swift
@@ -4,6 +4,7 @@ public class SpotifySdkConstants
 {
     //connecting
     public static let methodConnectToSpotify = "connectToSpotify"
+    public static let methodConnectToSpotifyTokenSwap = "connectToSpotifyTokenSwap"
     public static let methodGetAccessToken = "getAccessToken"
     public static let methodDisconnectFromSpotify = "disconnectFromSpotify"
 
@@ -31,6 +32,7 @@ public class SpotifySdkConstants
 
     public static let paramClientId = "clientId"
     public static let paramRedirectUrl = "redirectUrl"
+    public static let paramTokenSwapUrl = "tokenSwapUrl"
     public static let paramSpotifyUri = "spotifyUri"
     public static let paramAsRadio = "asRadio"
     public static let paramImageUri = "imageUri"
@@ -42,5 +44,8 @@ public class SpotifySdkConstants
     public static let paramRepeatMode = "repeatMode"
     public static let paramTrackIndex = "trackIndex"
     public static let scope = "scope"
+    public static let paramScopes = "scopes"
     public static let getLibraryState = "getLibraryState"
+
+    public static let methodIsSpotifyInstalled = "isSpotifyInstalled"
 }

--- a/ios/Classes/SwiftAppDelegate.swift
+++ b/ios/Classes/SwiftAppDelegate.swift
@@ -1,0 +1,38 @@
+import Flutter
+import UIKit
+
+extension FlutterAppDelegate {
+    open override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        let result = super.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+        // Initialize Spotify-specific components
+        SwiftSpotifySdkPlugin.register(with: self.registrar(forPlugin: "SwiftSpotifySdkPlugin")!)
+
+        return result
+    }
+
+    open override func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
+
+        // Handle Spotify URL callback
+        if let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
+            let urlSchemes = urlTypes.first?["CFBundleURLSchemes"] as? [String],
+            let urlScheme = urlSchemes.first
+        {
+            if url.scheme == urlScheme && url.host == "auth" {
+                if url.path == "/spotify/callback" {
+                    SwiftSpotifySdkPlugin.shared.handleSpotifyCallback(url: url)
+                    return true
+                }
+            }
+        }
+
+        return super.application(app, open: url, options: options)
+    }
+}

--- a/ios/Classes/SwiftAppDelegate.swift
+++ b/ios/Classes/SwiftAppDelegate.swift
@@ -21,7 +21,7 @@ public class SpotifyAppDelegate {
     ) -> Bool {
         // Handle Spotify URL callback
         if let value = Bundle.main.infoDictionary?["SpotifySDKCallbackURL"] as? String {
-            if url.absoluteString == value {
+            if url.absoluteString.contains(value) {
                 SwiftSpotifySdkPlugin.shared.handleSpotifyCallback(url: url)
                 return true
             }

--- a/ios/Classes/SwiftAppDelegate.swift
+++ b/ios/Classes/SwiftAppDelegate.swift
@@ -1,25 +1,24 @@
 import Flutter
 import UIKit
 
-extension FlutterAppDelegate {
-    open override func application(
+public class SpotifyAppDelegate {
+    public static func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {
-        let result = super.application(application, didFinishLaunchingWithOptions: launchOptions)
-
+    ) {
         // Initialize Spotify-specific components
-        SwiftSpotifySdkPlugin.register(with: self.registrar(forPlugin: "SwiftSpotifySdkPlugin")!)
-
-        return result
+        if let registrar = (application.delegate as? FlutterAppDelegate)?.registrar(
+            forPlugin: "SwiftSpotifySdkPlugin")
+        {
+            SwiftSpotifySdkPlugin.register(with: registrar)
+        }
     }
 
-    open override func application(
+    public static func application(
         _ app: UIApplication,
         open url: URL,
         options: [UIApplication.OpenURLOptionsKey: Any] = [:]
     ) -> Bool {
-
         // Handle Spotify URL callback
         if let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
             let urlSchemes = urlTypes.first?["CFBundleURLSchemes"] as? [String],
@@ -33,6 +32,6 @@ extension FlutterAppDelegate {
             }
         }
 
-        return super.application(app, open: url, options: options)
+        return false
     }
 }

--- a/ios/Classes/SwiftAppDelegate.swift
+++ b/ios/Classes/SwiftAppDelegate.swift
@@ -20,15 +20,10 @@ public class SpotifyAppDelegate {
         options: [UIApplication.OpenURLOptionsKey: Any] = [:]
     ) -> Bool {
         // Handle Spotify URL callback
-        if let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
-            let urlSchemes = urlTypes.first?["CFBundleURLSchemes"] as? [String],
-            let urlScheme = urlSchemes.first
-        {
-            if url.scheme == urlScheme && url.host == "auth" {
-                if url.path == "/spotify/callback" {
-                    SwiftSpotifySdkPlugin.shared.handleSpotifyCallback(url: url)
-                    return true
-                }
+        if let value = Bundle.main.infoDictionary?["SpotifySDKCallbackURL"] as? String {
+            if url.absoluteString == value {
+                SwiftSpotifySdkPlugin.shared.handleSpotifyCallback(url: url)
+                return true
             }
         }
 

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -10,6 +10,9 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
     private static var playerStateChannel: FlutterEventChannel?
     private static var playerContextChannel: FlutterEventChannel?
 
+    public var sessionManager: SPTSessionManager?
+    private var authCallback: FlutterResult?
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         guard playerStateChannel == nil else {
             // Avoid multiple plugin registations
@@ -69,6 +72,36 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
                 result(FlutterError(code: "CouldNotFindSpotifyApp", message: "The Spotify app is not installed on the device", details: nil))
                 return
             }
+
+        case SpotifySdkConstants.methodConnectToSpotifyTokenSwap:
+            guard let args = call.arguments as? [String: Any],
+                  let clientId = args["clientId"] as? String,
+                  let redirectUri = args["redirectUri"] as? String,
+                  let scopesString = args["scopes"] as? String,
+                  let tokenSwapUrl = args["tokenSwapUrl"] as? String else {
+                result(FlutterError(code: "INVALID_ARGUMENTS",
+                                    message: "Missing required arguments",
+                                    details: nil))
+                return
+            }
+
+            if !isSpotifyInstalled() {
+                result(FlutterError(code: "SPOTIFY_NOT_INSTALLED",
+                                    message: "Spotify app is not installed",
+                                    details: nil))
+                return
+            }
+            
+            authenticateTokenSwap(
+                clientId: clientId,
+                redirectUri: redirectUri,
+                scopes: scopesString.components(separatedBy: " "),
+                tokenSwapUrl: tokenSwapUrl,
+                result: result
+            )
+
+        case SpotifySdkConstants.methodIsSpotifyInstalled:
+            result(isSpotifyInstalled())
 
         case SpotifySdkConstants.methodGetAccessToken:
             guard let swiftArguments = call.arguments as? [String:Any],
@@ -370,9 +403,107 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
           }
         }
     }
+
+    private func isSpotifyInstalled() -> Bool {
+        return UIApplication.shared.canOpenURL(URL(string: "spotify:")!)
+    }
+
+    private func authenticateTokenSwap(
+        clientId: String,
+        redirectUri: String,
+        scopes: [String],
+        tokenSwapUrl: String,
+        result: @escaping FlutterResult
+    ) {
+        guard let redirectURL = URL(string: redirectUri) else {
+            result(FlutterError(code: "INVALID_URI",
+                              message: "Invalid redirect URI",
+                              details: nil))
+            return
+        }
+        
+        // Create configuration
+        let configuration = SPTConfiguration(clientID: clientId, redirectURL: redirectURL)
+        configuration.tokenSwapURL = URL(string: tokenSwapUrl)
+        
+        // Initialize session manager if needed
+        if sessionManager == nil {
+            sessionManager = SPTSessionManager(configuration: configuration, delegate: self)
+        }
+        
+        authCallback = result
+        
+        // Convert string scopes to SPTScope
+        let spotifyScopes: SPTScope = scopes.reduce(into: []) { result, scope in
+            switch scope {
+            case "user-read-private":
+                result.insert(.userReadPrivate)
+            case "user-read-email":
+                result.insert(.userReadEmail)
+            case "playlist-read-private":
+                result.insert(.playlistReadPrivate)
+            case "playlist-modify-public":
+                result.insert(.playlistModifyPublic)
+            case "playlist-modify-private":
+                result.insert(.playlistModifyPrivate)
+            case "user-library-read":
+                result.insert(.userLibraryRead)
+            case "user-library-modify":
+                result.insert(.userLibraryModify)
+            case "streaming":
+                result.insert(.streaming)
+            case "app-remote-control":
+                result.insert(.appRemoteControl)
+            case "user-follow-read":
+                result.insert(.userFollowRead)
+            case "user-follow-modify":
+                result.insert(.userFollowModify)
+            case "user-top-read":
+                result.insert(.userTopRead)
+            case "playlist-read-collaborative":
+                result.insert(.playlistReadCollaborative)
+            case "user-read-playback-state":
+                result.insert(.userReadPlaybackState)
+            case "user-modify-playback-state":
+                result.insert(.userModifyPlaybackState)
+            case "user-read-currently-playing":
+                result.insert(.userReadCurrentlyPlaying)
+            case "user-read-recently-played":
+                result.insert(.userReadRecentlyPlayed)
+            default:
+                break
+            }
+        }
+        
+        sessionManager?.initiateSession(with: spotifyScopes, options: .clientOnly, campaign: "app")
+    }
+    
+    public func handleSpotifyCallback(url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              let code = components.queryItems?.first(where: { $0.name == "code" })?.value else {
+            authCallback?(FlutterError(code: "INVALID_CALLBACK",
+                                     message: "Missing authorization code",
+                                     details: nil))
+            return
+        }
+        authCallback?(code)
+        authCallback = nil
+    }
 }
 
-extension SwiftSpotifySdkPlugin {
+extension SwiftSpotifySdkPlugin: SPTSessionManagerDelegate {
+    public func sessionManager(manager: SPTSessionManager, didInitiate session: SPTSession) {
+        authCallback?(session.accessToken)
+        authCallback = nil
+    }
+    
+    public func sessionManager(manager: SPTSessionManager, didFailWith error: Error) {
+        authCallback?(FlutterError(code: "AUTH_FAILED",
+                                 message: error.localizedDescription,
+                                 details: nil))
+        authCallback = nil
+    }
+    
     public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         setAccessTokenFromURL(url: url)
         return true

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -130,6 +130,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
 
         case SpotifySdkConstants.methodIsSpotifyInstalled:
             result(isSpotifyInstalled())
+            return
 
         case SpotifySdkConstants.methodGetAccessToken:
             guard let swiftArguments = call.arguments as? [String: Any],

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -94,7 +94,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
                 return
             }
 
-        case SpotifySdkConstants.getSwapToken:
+        case SpotifySdkConstants.methodGetSwapToken:
             guard let args = call.arguments as? [String: Any] else {
                 result(
                     FlutterError(

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -18,10 +18,14 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
             // Avoid multiple plugin registations
             return
         }
-        let spotifySDKChannel = FlutterMethodChannel(name: "spotify_sdk", binaryMessenger: registrar.messenger())
-        let connectionStatusChannel = FlutterEventChannel(name: "connection_status_subscription", binaryMessenger: registrar.messenger())
-        playerStateChannel = FlutterEventChannel(name: "player_state_subscription", binaryMessenger: registrar.messenger())
-        playerContextChannel = FlutterEventChannel(name: "player_context_subscription", binaryMessenger: registrar.messenger())
+        let spotifySDKChannel = FlutterMethodChannel(
+            name: "spotify_sdk", binaryMessenger: registrar.messenger())
+        let connectionStatusChannel = FlutterEventChannel(
+            name: "connection_status_subscription", binaryMessenger: registrar.messenger())
+        playerStateChannel = FlutterEventChannel(
+            name: "player_state_subscription", binaryMessenger: registrar.messenger())
+        playerContextChannel = FlutterEventChannel(
+            name: "player_context_subscription", binaryMessenger: registrar.messenger())
         registrar.addApplicationDelegate(instance)
         registrar.addMethodCallDelegate(instance, channel: spotifySDKChannel)
         instance.connectionStatusHandler = ConnectionStatusHandler()
@@ -30,73 +34,96 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         var defaultPlayAPICallback: SPTAppRemoteCallback {
-            get {
-                return {_, error in
-                    if let error = error {
-                        result(FlutterError(code: "PlayerAPI Error", message: error.localizedDescription, details: nil))
-                    } else {
-                        result(true)
-                    }
+            return { _, error in
+                if let error = error {
+                    result(
+                        FlutterError(
+                            code: "PlayerAPI Error", message: error.localizedDescription,
+                            details: nil))
+                } else {
+                    result(true)
                 }
             }
         }
 
         switch call.method {
         case SpotifySdkConstants.methodConnectToSpotify:
-            guard let swiftArguments = call.arguments as? [String:Any],
-                  let clientID = swiftArguments[SpotifySdkConstants.paramClientId] as? String,
-                  !clientID.isEmpty else {
-                result(FlutterError(code: "Argument Error", message: "Client ID is not set", details: nil))
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let clientID = swiftArguments[SpotifySdkConstants.paramClientId] as? String,
+                !clientID.isEmpty
+            else {
+                result(
+                    FlutterError(
+                        code: "Argument Error", message: "Client ID is not set", details: nil))
                 return
             }
 
             guard let url = swiftArguments[SpotifySdkConstants.paramRedirectUrl] as? String,
-                  !url.isEmpty else {
-                result(FlutterError(code: "Argument Error", message: "Redirect URL is not set", details: nil))
+                !url.isEmpty
+            else {
+                result(
+                    FlutterError(
+                        code: "Argument Error", message: "Redirect URL is not set", details: nil))
                 return
             }
 
             connectionStatusHandler?.connectionResult = result
 
-
-            let accessToken: String? = swiftArguments[SpotifySdkConstants.paramAccessToken] as? String
-            let spotifyUri: String = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String ?? ""
+            let accessToken: String? =
+                swiftArguments[SpotifySdkConstants.paramAccessToken] as? String
+            let spotifyUri: String =
+                swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String ?? ""
 
             do {
-                try connectToSpotify(clientId: clientID, redirectURL: url, accessToken: accessToken, spotifyUri: spotifyUri, asRadio: swiftArguments[SpotifySdkConstants.paramAsRadio] as? Bool, additionalScopes: swiftArguments[SpotifySdkConstants.scope] as? String)
-            }
-            catch SpotifyError.redirectURLInvalid {
-                result(FlutterError(code: "errorConnecting", message: "Redirect URL is not set or has invalid format", details: nil))
-            }
-            catch {
-                result(FlutterError(code: "CouldNotFindSpotifyApp", message: "The Spotify app is not installed on the device", details: nil))
+                try connectToSpotify(
+                    clientId: clientID, redirectURL: url, accessToken: accessToken,
+                    spotifyUri: spotifyUri,
+                    asRadio: swiftArguments[SpotifySdkConstants.paramAsRadio] as? Bool,
+                    additionalScopes: swiftArguments[SpotifySdkConstants.scope] as? String)
+            } catch SpotifyError.redirectURLInvalid {
+                result(
+                    FlutterError(
+                        code: "errorConnecting",
+                        message: "Redirect URL is not set or has invalid format", details: nil))
+            } catch {
+                result(
+                    FlutterError(
+                        code: "CouldNotFindSpotifyApp",
+                        message: "The Spotify app is not installed on the device", details: nil))
                 return
             }
 
         case SpotifySdkConstants.methodConnectToSpotifyTokenSwap:
             guard let args = call.arguments as? [String: Any],
-                  let clientId = args["clientId"] as? String,
-                  let redirectUri = args["redirectUri"] as? String,
-                  let scopesString = args["scopes"] as? String,
-                  let tokenSwapUrl = args["tokenSwapUrl"] as? String else {
-                result(FlutterError(code: "INVALID_ARGUMENTS",
-                                    message: "Missing required arguments",
-                                    details: nil))
+                let clientId = args["clientId"] as? String,
+                let redirectUri = args["redirectUri"] as? String,
+                let scopesString = args["scopes"] as? String,
+                let tokenSwapUrl = args["tokenSwapUrl"] as? String,
+                let tokenRefreshUrl = args["tokenRefreshUrl"] as? String?
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Missing required arguments",
+                        details: nil))
                 return
             }
 
             if !isSpotifyInstalled() {
-                result(FlutterError(code: "SPOTIFY_NOT_INSTALLED",
-                                    message: "Spotify app is not installed",
-                                    details: nil))
+                result(
+                    FlutterError(
+                        code: "SPOTIFY_NOT_INSTALLED",
+                        message: "Spotify app is not installed",
+                        details: nil))
                 return
             }
-            
+
             authenticateTokenSwap(
                 clientId: clientId,
                 redirectUri: redirectUri,
                 scopes: scopesString.components(separatedBy: " "),
                 tokenSwapUrl: tokenSwapUrl,
+                tokenRefreshUrl: tokenRefreshUrl,
                 result: result
             )
 
@@ -104,35 +131,54 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
             result(isSpotifyInstalled())
 
         case SpotifySdkConstants.methodGetAccessToken:
-            guard let swiftArguments = call.arguments as? [String:Any],
+            guard let swiftArguments = call.arguments as? [String: Any],
                 let clientID = swiftArguments[SpotifySdkConstants.paramClientId] as? String,
-                let url = swiftArguments[SpotifySdkConstants.paramRedirectUrl] as? String else {
-                    result(FlutterError(code: "Arguments Error", message: "One or more arguments are missing", details: nil))
-                    return
+                let url = swiftArguments[SpotifySdkConstants.paramRedirectUrl] as? String
+            else {
+                result(
+                    FlutterError(
+                        code: "Arguments Error", message: "One or more arguments are missing",
+                        details: nil))
+                return
             }
             connectionStatusHandler?.tokenResult = result
-            let spotifyUri: String = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String ?? ""
-            
+            let spotifyUri: String =
+                swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String ?? ""
+
             do {
-                try connectToSpotify(clientId: clientID, redirectURL: url, spotifyUri: spotifyUri, asRadio: swiftArguments[SpotifySdkConstants.paramAsRadio] as? Bool, additionalScopes: swiftArguments[SpotifySdkConstants.scope] as? String)
-            }
-            catch SpotifyError.redirectURLInvalid {
-                result(FlutterError(code: "errorConnecting", message: "Redirect URL is not set or has invalid format", details: nil))
-            }
-            catch {
-                result(FlutterError(code: "CouldNotFindSpotifyApp", message: "The Spotify app is not installed on the device", details: nil))
+                try connectToSpotify(
+                    clientId: clientID, redirectURL: url, spotifyUri: spotifyUri,
+                    asRadio: swiftArguments[SpotifySdkConstants.paramAsRadio] as? Bool,
+                    additionalScopes: swiftArguments[SpotifySdkConstants.scope] as? String)
+            } catch SpotifyError.redirectURLInvalid {
+                result(
+                    FlutterError(
+                        code: "errorConnecting",
+                        message: "Redirect URL is not set or has invalid format", details: nil))
+            } catch {
+                result(
+                    FlutterError(
+                        code: "CouldNotFindSpotifyApp",
+                        message: "The Spotify app is not installed on the device", details: nil))
                 return
             }
         case SpotifySdkConstants.methodGetImage:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
+            guard let swiftArguments = call.arguments as? [String: Any],
                 let paramImageUri = swiftArguments[SpotifySdkConstants.paramImageUri] as? String,
-                let paramImageDimension = swiftArguments[SpotifySdkConstants.paramImageDimension] as? Int else {
-                    result(FlutterError(code: "Arguments Error", message: "One or more arguments are missing", details: nil))
-                    return
+                let paramImageDimension = swiftArguments[SpotifySdkConstants.paramImageDimension]
+                    as? Int
+            else {
+                result(
+                    FlutterError(
+                        code: "Arguments Error", message: "One or more arguments are missing",
+                        details: nil))
+                return
             }
 
             class ImageObject: NSObject, SPTAppRemoteImageRepresentable {
@@ -141,138 +187,197 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
 
             let imageObject = ImageObject()
             imageObject.imageIdentifier = paramImageUri
-            appRemote.imageAPI?.fetchImage(forItem: imageObject, with: CGSize(width: paramImageDimension, height: paramImageDimension), callback: { (image, error) in
-                guard error == nil else {
-                    result(FlutterError(code: "ImageAPI Error", message: error?.localizedDescription, details: nil))
-                    return
-                }
-                guard let imageData = (image as? UIImage)?.pngData() else {
-                    result(FlutterError(code: "ImageAPI Error", message: "Image is empty", details: nil))
-                    return
-                }
-                result(imageData)
-            })
+            appRemote.imageAPI?.fetchImage(
+                forItem: imageObject,
+                with: CGSize(width: paramImageDimension, height: paramImageDimension),
+                callback: { (image, error) in
+                    guard error == nil else {
+                        result(
+                            FlutterError(
+                                code: "ImageAPI Error", message: error?.localizedDescription,
+                                details: nil))
+                        return
+                    }
+                    guard let imageData = (image as? UIImage)?.pngData() else {
+                        result(
+                            FlutterError(
+                                code: "ImageAPI Error", message: "Image is empty", details: nil))
+                        return
+                    }
+                    result(imageData)
+                })
         case SpotifySdkConstants.methodGetPlayerState:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            
+
             appRemote.playerAPI?.getPlayerState({ (playerState, error) in
                 guard error == nil else {
-                    result(FlutterError(code: "PlayerAPI Error", message: error?.localizedDescription, details: nil))
+                    result(
+                        FlutterError(
+                            code: "PlayerAPI Error", message: error?.localizedDescription,
+                            details: nil))
                     return
                 }
                 guard let playerState = playerState as? SPTAppRemotePlayerState else {
-                    result(FlutterError(code: "PlayerAPI Error", message: "PlayerState is empty", details: nil))
+                    result(
+                        FlutterError(
+                            code: "PlayerAPI Error", message: "PlayerState is empty", details: nil))
                     return
                 }
                 result(State.playerStateDictionary(playerState).json)
             })
         case SpotifySdkConstants.methodDisconnectFromSpotify:
             appRemote?.disconnect()
-//            appRemote?.connectionParameters.accessToken = nil
+            //            appRemote?.connectionParameters.accessToken = nil
             result(true)
         case SpotifySdkConstants.methodPlay:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
-                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String else {
-                    result(FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
-                    return
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String
+            else {
+                result(
+                    FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
+                return
             }
             let asRadio: Bool = (swiftArguments[SpotifySdkConstants.paramAsRadio] as? Bool) ?? false
             appRemote.playerAPI?.play(uri, asRadio: asRadio, callback: defaultPlayAPICallback)
         case SpotifySdkConstants.methodPause:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
             appRemote.playerAPI?.pause(defaultPlayAPICallback)
         case SpotifySdkConstants.methodResume:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
             appRemote.playerAPI?.resume(defaultPlayAPICallback)
         case SpotifySdkConstants.methodSkipNext:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
             appRemote.playerAPI?.skip(toNext: defaultPlayAPICallback)
         case SpotifySdkConstants.methodSkipPrevious:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
             appRemote.playerAPI?.skip(toPrevious: { (spotifyResult, error) in
                 if let error = error {
-                    result(FlutterError(code: "PlayerAPI Error", message: error.localizedDescription, details: nil))
+                    result(
+                        FlutterError(
+                            code: "PlayerAPI Error", message: error.localizedDescription,
+                            details: nil))
                     return
                 }
                 result(true)
             })
         case SpotifySdkConstants.methodSkipToIndex:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
-                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String else {
-                    result(FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
-                    return
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String
+            else {
+                result(
+                    FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
+                return
             }
             let index = (swiftArguments[SpotifySdkConstants.paramTrackIndex] as? Int) ?? 0
 
-            appRemote.contentAPI?.fetchContentItem(forURI: uri, callback: { (contentItemResult, error) in
-                guard error == nil else {
-                    result(FlutterError(code: "PlayerAPI Error", message: error?.localizedDescription, details: nil))
-                    return
-                }
-                guard let contentItem = contentItemResult as? SPTAppRemoteContentItem else {
-                    result(FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
-                    return
-                }
-                appRemote.playerAPI?.play(contentItem, skipToTrackIndex: index, callback: defaultPlayAPICallback)
-            })
+            appRemote.contentAPI?.fetchContentItem(
+                forURI: uri,
+                callback: { (contentItemResult, error) in
+                    guard error == nil else {
+                        result(
+                            FlutterError(
+                                code: "PlayerAPI Error", message: error?.localizedDescription,
+                                details: nil))
+                        return
+                    }
+                    guard let contentItem = contentItemResult as? SPTAppRemoteContentItem else {
+                        result(
+                            FlutterError(
+                                code: "URI Error", message: "No URI was specified", details: nil))
+                        return
+                    }
+                    appRemote.playerAPI?.play(
+                        contentItem, skipToTrackIndex: index, callback: defaultPlayAPICallback)
+                })
 
         case SpotifySdkConstants.methodAddToLibrary:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
-                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String else {
-                    result(FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
-                    return
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String
+            else {
+                result(
+                    FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
+                return
             }
             appRemote.userAPI?.addItemToLibrary(withURI: uri, callback: defaultPlayAPICallback)
         case SpotifySdkConstants.methodRemoveFromLibrary:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
-                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String else {
-                    result(FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
-                    return
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String
+            else {
+                result(
+                    FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
+                return
             }
             appRemote.userAPI?.removeItemFromLibrary(withURI: uri, callback: defaultPlayAPICallback)
         case SpotifySdkConstants.methodGetCapabilities:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
             appRemote.userAPI?.fetchCapabilities(callback: { (capabilitiesResult, error) in
                 guard error == nil else {
-                    result(FlutterError(code: "getCapabilitiesError", message: error?.localizedDescription, details: nil))
+                    result(
+                        FlutterError(
+                            code: "getCapabilitiesError", message: error?.localizedDescription,
+                            details: nil))
                     return
                 }
-                guard let userCapabilities = capabilitiesResult as? SPTAppRemoteUserCapabilities else {
-                    result(FlutterError(code: "getCapabilitiesError", message: error?.localizedDescription, details: nil))
+                guard let userCapabilities = capabilitiesResult as? SPTAppRemoteUserCapabilities
+                else {
+                    result(
+                        FlutterError(
+                            code: "getCapabilitiesError", message: error?.localizedDescription,
+                            details: nil))
                     return
                 }
 
@@ -280,94 +385,140 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
             })
         case SpotifySdkConstants.methodQueueTrack:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
-                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String else {
-                    result(FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
-                    return
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String
+            else {
+                result(
+                    FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
+                return
             }
             appRemote.playerAPI?.enqueueTrackUri(uri, callback: defaultPlayAPICallback)
         case SpotifySdkConstants.methodSeekTo:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
-                let position = swiftArguments[SpotifySdkConstants.paramPositionedMilliseconds] as? Int else {
-                    result(FlutterError(code: "Position error", message: "No position was specified", details: nil))
-                    return
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let position = swiftArguments[SpotifySdkConstants.paramPositionedMilliseconds]
+                    as? Int
+            else {
+                result(
+                    FlutterError(
+                        code: "Position error", message: "No position was specified", details: nil))
+                return
             }
             appRemote.playerAPI?.seek(toPosition: position, callback: defaultPlayAPICallback)
         case SpotifySdkConstants.methodGetCrossfadeState:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
             appRemote.playerAPI?.getCrossfadeState({ (crossfadeState, error) in
                 guard error == nil else {
-                    result(FlutterError(code: "PlayerAPI Error", message: error?.localizedDescription, details: nil))
+                    result(
+                        FlutterError(
+                            code: "PlayerAPI Error", message: error?.localizedDescription,
+                            details: nil))
                     return
                 }
                 guard let crossfadeState = crossfadeState as? SPTAppRemoteCrossfadeState else {
-                    result(FlutterError(code: "PlayerAPI Error", message: "PlayerState is empty", details: nil))
+                    result(
+                        FlutterError(
+                            code: "PlayerAPI Error", message: "PlayerState is empty", details: nil))
                     return
                 }
                 result(State.crossfadeStateDictionary(crossfadeState).json)
             })
         case SpotifySdkConstants.methodSetShuffle:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
-                let shuffle = swiftArguments[SpotifySdkConstants.paramShuffle] as? Bool else {
-                    result(FlutterError(code: "Shuffle mode error", message: "No ShuffleMode was specified", details: nil))
-                    return
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let shuffle = swiftArguments[SpotifySdkConstants.paramShuffle] as? Bool
+            else {
+                result(
+                    FlutterError(
+                        code: "Shuffle mode error", message: "No ShuffleMode was specified",
+                        details: nil))
+                return
             }
             appRemote.playerAPI?.setShuffle(shuffle, callback: defaultPlayAPICallback)
         case SpotifySdkConstants.methodSetRepeatMode:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
+            guard let swiftArguments = call.arguments as? [String: Any],
                 let repeatModeIndex = swiftArguments[SpotifySdkConstants.paramRepeatMode] as? UInt,
-                let repeatMode = SPTAppRemotePlaybackOptionsRepeatMode(rawValue: repeatModeIndex) else {
-                    result(FlutterError(code: "Repeat mode error", message: "No RepeatMode was specified", details: nil))
-                    return
+                let repeatMode = SPTAppRemotePlaybackOptionsRepeatMode(rawValue: repeatModeIndex)
+            else {
+                result(
+                    FlutterError(
+                        code: "Repeat mode error", message: "No RepeatMode was specified",
+                        details: nil))
+                return
             }
             appRemote.playerAPI?.setRepeatMode(repeatMode, callback: defaultPlayAPICallback)
         case SpotifySdkConstants.getLibraryState:
             guard let appRemote = appRemote else {
-                result(FlutterError(code: "Connection Error", message: "AppRemote is null", details: nil))
+                result(
+                    FlutterError(
+                        code: "Connection Error", message: "AppRemote is null", details: nil))
                 return
             }
-            guard let swiftArguments = call.arguments as? [String:Any],
-                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String else {
-                    result(FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
-                    return
+            guard let swiftArguments = call.arguments as? [String: Any],
+                let uri = swiftArguments[SpotifySdkConstants.paramSpotifyUri] as? String
+            else {
+                result(
+                    FlutterError(code: "URI Error", message: "No URI was specified", details: nil))
+                return
             }
-            appRemote.userAPI?.fetchLibraryState(forURI: uri, callback: {libraryStateResult, error in
-                guard error == nil else {
-                    result(FlutterError(code: "fetchLibraryStateError", message: error?.localizedDescription, details: nil))
-                    return
-                }
-                guard let libraryState = libraryStateResult as? SPTAppRemoteLibraryState else {
-                    result(FlutterError(code: "fetchLibraryStateError", message: error?.localizedDescription, details: nil))
-                    return
-                }
+            appRemote.userAPI?.fetchLibraryState(
+                forURI: uri,
+                callback: { libraryStateResult, error in
+                    guard error == nil else {
+                        result(
+                            FlutterError(
+                                code: "fetchLibraryStateError",
+                                message: error?.localizedDescription, details: nil))
+                        return
+                    }
+                    guard let libraryState = libraryStateResult as? SPTAppRemoteLibraryState else {
+                        result(
+                            FlutterError(
+                                code: "fetchLibraryStateError",
+                                message: error?.localizedDescription, details: nil))
+                        return
+                    }
 
-                result(State.libraryStateDictionary(libraryState).json)
-            })
+                    result(State.libraryStateDictionary(libraryState).json)
+                })
         default:
             result(FlutterMethodNotImplemented)
         }
     }
 
-    private func connectToSpotify(clientId: String, redirectURL: String, accessToken: String? = nil, spotifyUri: String = "", asRadio: Bool?, additionalScopes: String? = nil) throws {
-        func configureAppRemote(clientID: String, redirectURL: String, accessToken: String? = nil) throws {
+    private func connectToSpotify(
+        clientId: String, redirectURL: String, accessToken: String? = nil, spotifyUri: String = "",
+        asRadio: Bool?, additionalScopes: String? = nil
+    ) throws {
+        func configureAppRemote(clientID: String, redirectURL: String, accessToken: String? = nil)
+            throws
+        {
             guard let redirectURL = URL(string: redirectURL) else {
                 throw SpotifyError.redirectURLInvalid
             }
@@ -375,17 +526,20 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
             let appRemote = SPTAppRemote(configuration: configuration, logLevel: .none)
             appRemote.delegate = connectionStatusHandler
             let playerDelegate = PlayerDelegate()
-            playerStateHandler = PlayerStateHandler(appRemote: appRemote, playerDelegate: playerDelegate)
+            playerStateHandler = PlayerStateHandler(
+                appRemote: appRemote, playerDelegate: playerDelegate)
             SwiftSpotifySdkPlugin.playerStateChannel?.setStreamHandler(playerStateHandler)
 
-            playerContextHandler = PlayerContextHandler(appRemote: appRemote, playerDelegate: playerDelegate)
+            playerContextHandler = PlayerContextHandler(
+                appRemote: appRemote, playerDelegate: playerDelegate)
             SwiftSpotifySdkPlugin.playerContextChannel?.setStreamHandler(playerContextHandler)
 
             appRemote.connectionParameters.accessToken = accessToken
             self.appRemote = appRemote
         }
 
-        try configureAppRemote(clientID: clientId, redirectURL: redirectURL, accessToken: accessToken)
+        try configureAppRemote(
+            clientID: clientId, redirectURL: redirectURL, accessToken: accessToken)
 
         var scopes: [String]?
         if let additionalScopes = additionalScopes {
@@ -395,12 +549,17 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
         if accessToken != nil {
             appRemote?.connect()
         } else {
-          // Note: A blank string will play the user's last song or pick a random one.
-          self.appRemote?.authorizeAndPlayURI(spotifyUri, asRadio: asRadio ?? false, additionalScopes: scopes) { success in
-            if (!success) {
-              self.connectionStatusHandler?.connectionResult?(FlutterError(code: "spotifyNotInstalled", message: "Spotify app is not installed", details: nil))
+            // Note: A blank string will play the user's last song or pick a random one.
+            self.appRemote?.authorizeAndPlayURI(
+                spotifyUri, asRadio: asRadio ?? false, additionalScopes: scopes
+            ) { success in
+                if !success {
+                    self.connectionStatusHandler?.connectionResult?(
+                        FlutterError(
+                            code: "spotifyNotInstalled", message: "Spotify app is not installed",
+                            details: nil))
+                }
             }
-          }
         }
     }
 
@@ -413,26 +572,32 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
         redirectUri: String,
         scopes: [String],
         tokenSwapUrl: String,
+        tokenRefreshUrl: String?,
         result: @escaping FlutterResult
     ) {
         guard let redirectURL = URL(string: redirectUri) else {
-            result(FlutterError(code: "INVALID_URI",
-                              message: "Invalid redirect URI",
-                              details: nil))
+            result(
+                FlutterError(
+                    code: "INVALID_URI",
+                    message: "Invalid redirect URI",
+                    details: nil))
             return
         }
-        
+
         // Create configuration
         let configuration = SPTConfiguration(clientID: clientId, redirectURL: redirectURL)
         configuration.tokenSwapURL = URL(string: tokenSwapUrl)
-        
+        if tokenRefreshUrl !== nil {
+            configuration.tokenRefreshURL = URL(string: tokenRefreshUrl)
+        }
+
         // Initialize session manager if needed
         if sessionManager == nil {
             sessionManager = SPTSessionManager(configuration: configuration, delegate: self)
         }
-        
+
         authCallback = result
-        
+
         // Convert string scopes to SPTScope
         let spotifyScopes: SPTScope = scopes.reduce(into: []) { result, scope in
             switch scope {
@@ -474,16 +639,19 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
                 break
             }
         }
-        
+
         sessionManager?.initiateSession(with: spotifyScopes, options: .clientOnly, campaign: "app")
     }
-    
+
     public func handleSpotifyCallback(url: URL) {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-              let code = components.queryItems?.first(where: { $0.name == "code" })?.value else {
-            authCallback?(FlutterError(code: "INVALID_CALLBACK",
-                                     message: "Missing authorization code",
-                                     details: nil))
+            let code = components.queryItems?.first(where: { $0.name == "code" })?.value
+        else {
+            authCallback?(
+                FlutterError(
+                    code: "INVALID_CALLBACK",
+                    message: "Missing authorization code",
+                    details: nil))
             return
         }
         authCallback?(code)
@@ -496,28 +664,42 @@ extension SwiftSpotifySdkPlugin: SPTSessionManagerDelegate {
         authCallback?(session.accessToken)
         authCallback = nil
     }
-    
+
     public func sessionManager(manager: SPTSessionManager, didFailWith error: Error) {
-        authCallback?(FlutterError(code: "AUTH_FAILED",
-                                 message: error.localizedDescription,
-                                 details: nil))
+        authCallback?(
+            FlutterError(
+                code: "AUTH_FAILED",
+                message: error.localizedDescription,
+                details: nil))
         authCallback = nil
     }
-    
-    public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+
+    public func application(
+        _ application: UIApplication, open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
         setAccessTokenFromURL(url: url)
         return true
     }
 
-    public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]) -> Void) -> Bool {
+    public func application(
+        _ application: UIApplication, continue userActivity: NSUserActivity,
+        restorationHandler: @escaping ([Any]) -> Void
+    ) -> Bool {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
             let url = userActivity.webpageURL
-            else {
-                connectionStatusHandler?.connectionResult?(FlutterError(code: "errorConnecting", message: "client id or redirectUrl is invalid", details: nil))
-                connectionStatusHandler?.tokenResult?(FlutterError(code: "errorConnecting", message: "client id or redirectUrl is invalid", details: nil))
-                connectionStatusHandler?.connectionResult = nil
-                connectionStatusHandler?.tokenResult = nil
-                return false
+        else {
+            connectionStatusHandler?.connectionResult?(
+                FlutterError(
+                    code: "errorConnecting", message: "client id or redirectUrl is invalid",
+                    details: nil))
+            connectionStatusHandler?.tokenResult?(
+                FlutterError(
+                    code: "errorConnecting", message: "client id or redirectUrl is invalid",
+                    details: nil))
+            connectionStatusHandler?.connectionResult = nil
+            connectionStatusHandler?.tokenResult = nil
+            return false
         }
 
         setAccessTokenFromURL(url: url)
@@ -526,16 +708,27 @@ extension SwiftSpotifySdkPlugin: SPTSessionManagerDelegate {
 
     private func setAccessTokenFromURL(url: URL) {
         guard let appRemote = appRemote else {
-            connectionStatusHandler?.connectionResult?(FlutterError(code: "errorConnection", message: "AppRemote is null", details: nil))
-            connectionStatusHandler?.tokenResult?(FlutterError(code: "errorConnection", message: "AppRemote is null", details: nil))
+            connectionStatusHandler?.connectionResult?(
+                FlutterError(code: "errorConnection", message: "AppRemote is null", details: nil))
+            connectionStatusHandler?.tokenResult?(
+                FlutterError(code: "errorConnection", message: "AppRemote is null", details: nil))
             connectionStatusHandler?.connectionResult = nil
             connectionStatusHandler?.tokenResult = nil
             return
         }
 
-        guard let token = appRemote.authorizationParameters(from: url)?[SPTAppRemoteAccessTokenKey] else {
-            connectionStatusHandler?.connectionResult?(FlutterError(code: "authenticationTokenError", message: appRemote.authorizationParameters(from: url)?[SPTAppRemoteErrorDescriptionKey], details: nil))
-            connectionStatusHandler?.tokenResult?(FlutterError(code: "authenticationTokenError", message: appRemote.authorizationParameters(from: url)?[SPTAppRemoteErrorDescriptionKey], details: nil))
+        guard let token = appRemote.authorizationParameters(from: url)?[SPTAppRemoteAccessTokenKey]
+        else {
+            connectionStatusHandler?.connectionResult?(
+                FlutterError(
+                    code: "authenticationTokenError",
+                    message: appRemote.authorizationParameters(from: url)?[
+                        SPTAppRemoteErrorDescriptionKey], details: nil))
+            connectionStatusHandler?.tokenResult?(
+                FlutterError(
+                    code: "authenticationTokenError",
+                    message: appRemote.authorizationParameters(from: url)?[
+                        SPTAppRemoteErrorDescriptionKey], details: nil))
             connectionStatusHandler?.connectionResult = nil
             connectionStatusHandler?.tokenResult = nil
             return

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -95,21 +95,30 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
             }
 
         case SpotifySdkConstants.methodConnectToSpotifyTokenSwap:
-            guard let args = call.arguments as? [String: Any],
-                let clientId = args["clientId"] as? String,
-                let redirectUri = args["redirectUri"] as? String,
-                let scopesString = args["scopes"] as? String,
-                let tokenSwapUrl = args["tokenSwapUrl"] as? String,
-                let tokenRefreshUrl = args["tokenRefreshUrl"] as? String?
-            else {
+            guard let args = call.arguments as? [String: Any] else {
                 result(
                     FlutterError(
-                        code: "INVALID_ARGUMENTS",
-                        message: "Missing required arguments",
-                        details: nil))
+                    code: "INVALID_ARGUMENTS",
+                    message: "Arguments are not a dictionary: \(String(describing: call.arguments))",
+                    details: nil))
                 return
             }
 
+            guard let clientId = args["clientId"] as? String,
+                let redirectUrl = args["redirectUrl"] as? String,
+                let scopesString = args["scopes"] as? String,
+                let tokenSwapUrl = args["tokenSwapUrl"] as? String
+                else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Missing required arguments. Received arguments: \(args)",
+                        details: nil))
+                return
+            }
+            let tokenRefreshUrl = args["tokenRefreshUrl"] as? String
+
+            // Check if Spotify is installed
             if !isSpotifyInstalled() {
                 result(
                     FlutterError(
@@ -121,8 +130,8 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
 
             authenticateTokenSwap(
                 clientId: clientId,
-                redirectUri: redirectUri,
-                scopes: scopesString.components(separatedBy: " "),
+                redirectUri: redirectUrl,
+                scopes: scopesString.components(separatedBy: ","),
                 tokenSwapUrl: tokenSwapUrl,
                 tokenRefreshUrl: tokenRefreshUrl,
                 result: result

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -94,7 +94,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
                 return
             }
 
-        case SpotifySdkConstants.methodConnectToSpotifyTokenSwap:
+        case SpotifySdkConstants.getSwapToken:
             guard let args = call.arguments as? [String: Any] else {
                 result(
                     FlutterError(
@@ -116,7 +116,6 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
                         details: nil))
                 return
             }
-            let tokenRefreshUrl = args["tokenRefreshUrl"] as? String
 
             // Check if Spotify is installed
             if !isSpotifyInstalled() {
@@ -133,7 +132,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
                 redirectUri: redirectUrl,
                 scopes: scopesString.components(separatedBy: ","),
                 tokenSwapUrl: tokenSwapUrl,
-                tokenRefreshUrl: tokenRefreshUrl,
+                tokenRefreshUrl: nil,
                 result: result
             )
 

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -3,6 +3,7 @@ import SpotifyiOS
 
 public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
     private static var instance = SwiftSpotifySdkPlugin()
+    public static var shared: SwiftSpotifySdkPlugin { return instance }
     private var appRemote: SPTAppRemote?
     private var connectionStatusHandler: ConnectionStatusHandler?
     private var playerStateHandler: PlayerStateHandler?
@@ -587,7 +588,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin {
         // Create configuration
         let configuration = SPTConfiguration(clientID: clientId, redirectURL: redirectURL)
         configuration.tokenSwapURL = URL(string: tokenSwapUrl)
-        if tokenRefreshUrl !== nil {
+        if let tokenRefreshUrl = tokenRefreshUrl {
             configuration.tokenRefreshURL = URL(string: tokenRefreshUrl)
         }
 

--- a/lib/platform_channels.dart
+++ b/lib/platform_channels.dart
@@ -27,8 +27,8 @@ class MethodNames {
   /// method name for [connectToSpotify]
   static const String connectToSpotify = 'connectToSpotify';
 
-  /// method name for [connectToSpotifyTokenSwap]
-  static const String connectToSpotifyTokenSwap = 'connectToSpotifyTokenSwap';
+  /// method name for [getSwapToken]
+  static const String getSwapToken = 'getSwapToken';
 
   /// method name for [getAccessToken]
   static const String getAccessToken = 'getAccessToken';

--- a/lib/platform_channels.dart
+++ b/lib/platform_channels.dart
@@ -132,6 +132,9 @@ class ParamNames {
   /// param name for [tokenSwapUrl]
   static const String tokenSwapUrl = 'tokenSwapUrl';
 
+  /// param name for [tokenRefreshUrl]
+  static const String tokenRefreshUrl = 'tokenRefreshUrl';
+
   /// param name for [playerName]
   static const String playerName = 'playerName';
 

--- a/lib/platform_channels.dart
+++ b/lib/platform_channels.dart
@@ -27,6 +27,9 @@ class MethodNames {
   /// method name for [connectToSpotify]
   static const String connectToSpotify = 'connectToSpotify';
 
+  /// method name for [connectToSpotifyTokenSwap]
+  static const String connectToSpotifyTokenSwap = 'connectToSpotifyTokenSwap';
+
   /// method name for [getAccessToken]
   static const String getAccessToken = 'getAccessToken';
 
@@ -107,6 +110,9 @@ class MethodNames {
 
   /// method name for [switchToLocalDevice]
   static const String switchToLocalDevice = "switchToLocalDevice";
+
+  /// method name for [isSpotifyInstalled]
+  static const String isSpotifyInstalled = 'isSpotifyInstalled';
 }
 
 /// Holds the names for all parameters that are used in the package
@@ -119,6 +125,12 @@ class ParamNames {
 
   /// param name for [scope]
   static const String scope = 'scope';
+
+  /// param name for [scopes]
+  static const String scopes = 'scopes';
+
+  /// param name for [tokenSwapUrl]
+  static const String tokenSwapUrl = 'tokenSwapUrl';
 
   /// param name for [playerName]
   static const String playerName = 'playerName';

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -101,13 +101,14 @@ class SpotifySdk {
   /// Only available on iOS currently
   ///
   /// This method is used to connect to Spotify using token swap authentication.
-  /// It requires a [clientId], [redirectUrl], [scopes], and [tokenSwapUrl].
+  /// It requires a [clientId], [redirectUrl], [scopes], [tokenSwapUrl], and [tokenRefreshUrl].
   /// Throws a [PlatformException] if the connection fails.
   static Future<bool> connectToSpotifyTokenSwap({
     required String clientId,
     required String redirectUrl,
     required List<String> scopes,
     required String tokenSwapUrl,
+    required String? tokenRefreshUrl,
   }) async {
     /// Check if Spotify is installed
     if (!await isSpotifyInstalled().catchError((_) => false)) {
@@ -123,6 +124,7 @@ class SpotifySdk {
         ParamNames.redirectUrl: redirectUrl,
         ParamNames.scopes: scopes,
         ParamNames.tokenSwapUrl: tokenSwapUrl,
+        ParamNames.tokenRefreshUrl: tokenRefreshUrl,
       });
     } on Exception catch (e) {
       _logException(MethodNames.connectToSpotifyTokenSwap, e);

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -103,7 +103,7 @@ class SpotifySdk {
   /// This method is used to connect to Spotify using token swap authentication.
   /// It requires a [clientId], [redirectUrl], [scopes], [tokenSwapUrl], and [tokenRefreshUrl].
   /// Throws a [PlatformException] if the connection fails.
-  static Future<bool> connectToSpotifyTokenSwap({
+  static Future<String?> connectToSpotifyTokenSwap({
     required String clientId,
     required String redirectUrl,
     required List<String> scopes,
@@ -118,14 +118,23 @@ class SpotifySdk {
     }
 
     try {
-      return await _channel
-          .invokeMethod(MethodNames.connectToSpotifyTokenSwap, {
+      String swapToken =
+          await _channel.invokeMethod(MethodNames.connectToSpotifyTokenSwap, {
         ParamNames.clientId: clientId,
         ParamNames.redirectUrl: redirectUrl,
         ParamNames.scopes: scopes,
         ParamNames.tokenSwapUrl: tokenSwapUrl,
         ParamNames.tokenRefreshUrl: tokenRefreshUrl,
       });
+
+      // Return the swap token if there is no refresh url
+      if (tokenRefreshUrl == null) {
+        return swapToken;
+      }
+
+      /// TODO: Refresh the token if the refresh url is provided
+
+      return null;
     } on Exception catch (e) {
       _logException(MethodNames.connectToSpotifyTokenSwap, e);
       rethrow;

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -98,8 +98,6 @@ class SpotifySdk {
 
   /// Returns a swap token for Spotify using token swap authentication
   ///
-  /// Only available on iOS currently
-  ///
   /// This method is used to connect to Spotify using token swap authentication.
   /// It requires a [clientId], [redirectUrl], [scopes], and a [tokenSwapUrl].
   /// Throws a [PlatformException] if the connection fails.

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -96,49 +96,35 @@ class SpotifySdk {
     }
   }
 
-  /// Connects to Spotify using token swap authentication
+  /// Returns a swap token for Spotify using token swap authentication
   ///
   /// Only available on iOS currently
   ///
   /// This method is used to connect to Spotify using token swap authentication.
-  /// It requires a [clientId], [redirectUrl], [scopes], [tokenSwapUrl], and [tokenRefreshUrl].
+  /// It requires a [clientId], [redirectUrl], [scopes], and a [tokenSwapUrl].
   /// Throws a [PlatformException] if the connection fails.
-  ///
-  /// Will only return a swap token if [tokenRefreshUrl] is null.
-  static Future<String?> connectToSpotifyTokenSwap({
+  static Future<String> getSwapToken({
     required String clientId,
     required String redirectUrl,
     required List<String> scopes,
     required String tokenSwapUrl,
-    required String? tokenRefreshUrl,
   }) async {
     /// Check if Spotify is installed
     if (!await isSpotifyInstalled().catchError((_) => false)) {
       var e = Exception('Spotify is not installed');
-      _logException(MethodNames.connectToSpotifyTokenSwap, e);
+      _logException(MethodNames.getSwapToken, e);
       throw e;
     }
 
     try {
-      String swapToken =
-          await _channel.invokeMethod(MethodNames.connectToSpotifyTokenSwap, {
+      return await _channel.invokeMethod(MethodNames.getSwapToken, {
         ParamNames.clientId: clientId,
         ParamNames.redirectUrl: redirectUrl,
         ParamNames.scopes: scopes.join(','),
         ParamNames.tokenSwapUrl: tokenSwapUrl,
-        ParamNames.tokenRefreshUrl: tokenRefreshUrl,
       });
-
-      // Return the swap token if there is no refresh url
-      if (tokenRefreshUrl == null) {
-        return swapToken;
-      }
-
-      /// TODO: Refresh the token if the refresh url is provided
-
-      return null;
     } on Exception catch (e) {
-      _logException(MethodNames.connectToSpotifyTokenSwap, e);
+      _logException(MethodNames.getSwapToken, e);
       rethrow;
     }
   }

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -103,6 +103,8 @@ class SpotifySdk {
   /// This method is used to connect to Spotify using token swap authentication.
   /// It requires a [clientId], [redirectUrl], [scopes], [tokenSwapUrl], and [tokenRefreshUrl].
   /// Throws a [PlatformException] if the connection fails.
+  ///
+  /// Will only return a swap token if [tokenRefreshUrl] is null.
   static Future<String?> connectToSpotifyTokenSwap({
     required String clientId,
     required String redirectUrl,

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -122,7 +122,7 @@ class SpotifySdk {
           await _channel.invokeMethod(MethodNames.connectToSpotifyTokenSwap, {
         ParamNames.clientId: clientId,
         ParamNames.redirectUrl: redirectUrl,
-        ParamNames.scopes: scopes,
+        ParamNames.scopes: scopes.join(','),
         ParamNames.tokenSwapUrl: tokenSwapUrl,
         ParamNames.tokenRefreshUrl: tokenRefreshUrl,
       });

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -96,6 +96,40 @@ class SpotifySdk {
     }
   }
 
+  /// Connects to Spotify using token swap authentication
+  ///
+  /// Only available on iOS currently
+  ///
+  /// This method is used to connect to Spotify using token swap authentication.
+  /// It requires a [clientId], [redirectUrl], [scopes], and [tokenSwapUrl].
+  /// Throws a [PlatformException] if the connection fails.
+  static Future<bool> connectToSpotifyTokenSwap({
+    required String clientId,
+    required String redirectUrl,
+    required List<String> scopes,
+    required String tokenSwapUrl,
+  }) async {
+    /// Check if Spotify is installed
+    if (!await isSpotifyInstalled().catchError((_) => false)) {
+      var e = Exception('Spotify is not installed');
+      _logException(MethodNames.connectToSpotifyTokenSwap, e);
+      throw e;
+    }
+
+    try {
+      return await _channel
+          .invokeMethod(MethodNames.connectToSpotifyTokenSwap, {
+        ParamNames.clientId: clientId,
+        ParamNames.redirectUrl: redirectUrl,
+        ParamNames.scopes: scopes,
+        ParamNames.tokenSwapUrl: tokenSwapUrl,
+      });
+    } on Exception catch (e) {
+      _logException(MethodNames.connectToSpotifyTokenSwap, e);
+      rethrow;
+    }
+  }
+
   /// Returns an access token as a [String]
   ///
   /// Required parameters are the [clientId] and the [redirectUrl] to
@@ -642,6 +676,23 @@ class SpotifySdk {
           MethodNames.setRepeatMode, {ParamNames.repeatMode: repeatMode.index});
     } on Exception catch (e) {
       _logException(MethodNames.setRepeatMode, e);
+      rethrow;
+    }
+  }
+
+  /// Checks if Spotify is installed on the device
+  ///
+  /// Only available on iOS currently
+  ///
+  /// Returns true if Spotify is installed, false otherwise
+  /// Throws a [PlatformException] if checking fails
+  /// Throws a [MissingPluginException] if the method is not implemented on
+  /// the native platforms.
+  static Future<bool> isSpotifyInstalled() async {
+    try {
+      return await _channel.invokeMethod(MethodNames.isSpotifyInstalled);
+    } on Exception catch (e) {
+      _logException(MethodNames.isSpotifyInstalled, e);
       rethrow;
     }
   }


### PR DESCRIPTION
Note: Mobile implementation currently is only for getting the Swap token to exchange for a real token. It will not authenticate the SpotifySdk's other functions.

Supports iOS and Android.